### PR TITLE
Refine sidebar settings navigation

### DIFF
--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -13,7 +13,13 @@ export default function Brands() {
   return (
     <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail />
+        <HierarchyDetail
+          emptyState={
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+              中央のブランド一覧からブランドを選択すると詳細がここに表示されます。
+            </div>
+          }
+        />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-slate-900">ブランド一覧</h2>

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const brands = [
@@ -12,17 +12,22 @@ const brands = [
 export default function Brands() {
   return (
     <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }]}>
-      <div className="flex items-center justify-between mb-3">
-        <h1 className="font-semibold">ブランド一覧</h1>
-        <AddButton href="/brands/new">新規登録</AddButton>
-      </div>
-      <div className="grid gap-3">
-        {brands.map(b => (
-          <Link key={b.id} href={`/brands/${b.id}`} className="card p-4 card-hover">
-            <div className="font-medium">{b.name}</div>
-            <div className="text-sm text-slate-500">{b.account}</div>
-          </Link>
-        ))}
+      <div className="space-y-8">
+        <HierarchyDetail />
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-slate-900">ブランドコレクション</h2>
+            <AddButton href="/brands/new">新規登録</AddButton>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {brands.map(b => (
+              <Link key={b.id} href={`/brands/${b.id}`} className="card card-hover flex flex-col gap-1 p-4">
+                <div className="font-medium text-slate-900">{b.name}</div>
+                <div className="text-sm text-slate-500">{b.account}</div>
+              </Link>
+            ))}
+          </div>
+        </section>
       </div>
     </Shell>
   )

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -4,9 +4,9 @@ import { HierarchyDetail, Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const brands = [
-  { id: 'brd_shoestore', name: 'ShoeStore', account: 'Global Retail Inc.' },
-  { id: 'brd_gadgets', name: 'Gadgets+', account: 'Global Retail Inc.' },
-  { id: 'brd_futuretech', name: 'FutureTech Gear', account: 'Tech Starter' },
+  { id: 'brand-shoestore', name: 'ShoeStore', account: 'A社（Global Retail Inc.）' },
+  { id: 'brand-gadgets', name: 'Gadgets+', account: 'A社（Global Retail Inc.）' },
+  { id: 'brand-futuretech', name: 'FutureTech Gear', account: 'B社（Tech Starter）' },
 ]
 
 export default function Brands() {
@@ -16,7 +16,7 @@ export default function Brands() {
         <HierarchyDetail />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-slate-900">ブランドコレクション</h2>
+            <h2 className="text-lg font-semibold text-slate-900">ブランド一覧</h2>
             <AddButton href="/brands/new">新規登録</AddButton>
           </div>
           <div className="grid gap-3 md:grid-cols-2">

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { HierarchyDetail, Shell } from '@/components/Shell'
+import { Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const brands = [
@@ -13,13 +13,6 @@ export default function Brands() {
   return (
     <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail
-          emptyState={
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
-              中央のブランド一覧からブランドを選択すると詳細がここに表示されます。
-            </div>
-          }
-        />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-slate-900">ブランド一覧</h2>

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { HierarchyDetail, Shell } from '@/components/Shell'
+import { Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const customers = [
@@ -12,13 +12,6 @@ export default function Customers() {
   return (
     <Shell crumbs={[{ href: '/customers', label: '顧客一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail
-          emptyState={
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
-              中央の顧客一覧からアカウントを選択すると詳細がここに表示されます。
-            </div>
-          }
-        />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-slate-900">顧客一覧</h2>

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -12,7 +12,13 @@ export default function Customers() {
   return (
     <Shell crumbs={[{ href: '/customers', label: '顧客一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail />
+        <HierarchyDetail
+          emptyState={
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+              中央の顧客一覧からアカウントを選択すると詳細がここに表示されます。
+            </div>
+          }
+        />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-slate-900">顧客一覧</h2>

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const customers = [
@@ -11,17 +11,22 @@ const customers = [
 export default function Customers() {
   return (
     <Shell crumbs={[{ href: '/customers', label: '顧客一覧' }]}>
-      <div className="flex items-center justify-between mb-3">
-        <h1 className="font-semibold">顧客一覧</h1>
-        <AddButton href="/customers/new">新規登録</AddButton>
-      </div>
-      <div className="grid gap-3">
-        {customers.map(c => (
-          <Link key={c.id} href={`/customers/${c.id}`} className="card p-4 card-hover">
-            <div className="font-medium">{c.name}</div>
-            <div className="text-sm text-slate-500">{c.website}</div>
-          </Link>
-        ))}
+      <div className="space-y-8">
+        <HierarchyDetail />
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-slate-900">顧客ライブラリ</h2>
+            <AddButton href="/customers/new">新規登録</AddButton>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {customers.map(c => (
+              <Link key={c.id} href={`/customers/${c.id}`} className="card card-hover flex flex-col gap-1 p-4">
+                <div className="font-medium text-slate-900">{c.name}</div>
+                <div className="text-sm text-slate-500">{c.website}</div>
+              </Link>
+            ))}
+          </div>
+        </section>
       </div>
     </Shell>
   )

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -4,8 +4,8 @@ import { HierarchyDetail, Shell } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
 
 const customers = [
-  { id: 'acc_globalretail', name: 'A社（Global Retail Inc.）', website: 'https://www.globalretail.example' },
-  { id: 'acc_techstarter', name: 'B社（Tech Starter）', website: 'https://www.techstarter.example' },
+  { id: 'cust-global-retail', name: 'A社（Global Retail Inc.）', website: 'https://www.globalretail.example' },
+  { id: 'cust-tech-starter', name: 'B社（Tech Starter）', website: 'https://www.techstarter.example' },
 ]
 
 export default function Customers() {
@@ -15,7 +15,7 @@ export default function Customers() {
         <HierarchyDetail />
         <section className="space-y-3">
           <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-slate-900">顧客ライブラリ</h2>
+            <h2 className="text-lg font-semibold text-slate-900">顧客一覧</h2>
             <AddButton href="/customers/new">新規登録</AddButton>
           </div>
           <div className="grid gap-3 md:grid-cols-2">

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -12,7 +12,13 @@ export default function Programs() {
   return (
     <Shell crumbs={[{ href: '/programs', label: 'プログラム一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail />
+        <HierarchyDetail
+          emptyState={
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+              中央のプログラム一覧からプログラムを選択すると詳細がここに表示されます。
+            </div>
+          }
+        />
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-slate-900">プログラム一覧</h2>
           <div className="grid gap-3 md:grid-cols-2">

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { HierarchyDetail, Shell } from '@/components/Shell'
+import { Shell } from '@/components/Shell'
 
 const programs = [
   { id: 'prog-bidding', name: '入札最適化プログラム' },
@@ -12,13 +12,6 @@ export default function Programs() {
   return (
     <Shell crumbs={[{ href: '/programs', label: 'プログラム一覧' }]}>
       <div className="space-y-8">
-        <HierarchyDetail
-          emptyState={
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
-              中央のプログラム一覧からプログラムを選択すると詳細がここに表示されます。
-            </div>
-          }
-        />
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-slate-900">プログラム一覧</h2>
           <div className="grid gap-3 md:grid-cols-2">

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell } from '@/components/Shell'
 
 const programs = [
   { id: 'pg_bidding', name: '入札最適化プログラム' },
@@ -10,12 +10,18 @@ const programs = [
 export default function Programs() {
   return (
     <Shell crumbs={[{ href: '/programs', label: 'プログラム一覧' }]}>
-      <div className="grid gap-3">
-        {programs.map(p => (
-          <Link key={p.id} href={`/programs/${p.id}`} className="card p-4 card-hover">
-            <div className="font-medium">{p.name}</div>
-          </Link>
-        ))}
+      <div className="space-y-8">
+        <HierarchyDetail />
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900">プログラムライブラリ</h2>
+          <div className="grid gap-3 md:grid-cols-2">
+            {programs.map(p => (
+              <Link key={p.id} href={`/programs/${p.id}`} className="card card-hover flex flex-col gap-1 p-4">
+                <div className="font-medium text-slate-900">{p.name}</div>
+              </Link>
+            ))}
+          </div>
+        </section>
       </div>
     </Shell>
   )

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -3,8 +3,9 @@ import Link from 'next/link'
 import { HierarchyDetail, Shell } from '@/components/Shell'
 
 const programs = [
-  { id: 'pg_bidding', name: '入札最適化プログラム' },
-  { id: 'pg_reporting', name: '週次レポート自動化プログラム' },
+  { id: 'prog-bidding', name: '入札最適化プログラム' },
+  { id: 'prog-reporting', name: '週次レポート自動化プログラム' },
+  { id: 'prog-expansion', name: '国際展開プログラム' },
 ]
 
 export default function Programs() {
@@ -13,7 +14,7 @@ export default function Programs() {
       <div className="space-y-8">
         <HierarchyDetail />
         <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-slate-900">プログラムライブラリ</h2>
+          <h2 className="text-lg font-semibold text-slate-900">プログラム一覧</h2>
           <div className="grid gap-3 md:grid-cols-2">
             {programs.map(p => (
               <Link key={p.id} href={`/programs/${p.id}`} className="card card-hover flex flex-col gap-1 p-4">

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -560,15 +560,9 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
   const customer = pickCustomer(sp, pathname)
 
   if (!customer) {
-    const activeSection = sp?.get('section') ?? 'list'
+    const requestedSection = sp?.get('section')
+    const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
     const navDefinitions: ModeNavDefinition[] = [
-      {
-        path: '/customers',
-        label: '顧客一覧',
-        description: '登録済み顧客を俯瞰',
-        icon: Users2,
-        params: { section: 'list' },
-      },
       {
         path: '/customers',
         label: 'コンテキスト',
@@ -910,15 +904,9 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
   }
 
   if (!requestedBrandId) {
-    const activeSection = sp?.get('section') ?? 'list'
+    const requestedSection = sp?.get('section')
+    const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
     const navDefinitions: ModeNavDefinition[] = [
-      {
-        path: '/brands',
-        label: 'ブランド一覧',
-        description: '登録済みブランドを俯瞰',
-        icon: Landmark,
-        params: { section: 'list' },
-      },
       {
         path: '/brands',
         label: 'コンテキスト',
@@ -1219,15 +1207,9 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
   }
 
   if (!requestedProgramId) {
-    const activeSection = sp?.get('section') ?? 'list'
+    const requestedSection = sp?.get('section')
+    const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
     const navDefinitions: ModeNavDefinition[] = [
-      {
-        path: '/programs',
-        label: 'プログラム一覧',
-        description: '進行中の取り組みを俯瞰',
-        icon: Layers,
-        params: { section: 'list' },
-      },
       {
         path: '/programs',
         label: 'コンテキスト',

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -565,6 +565,13 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
     const navDefinitions: ModeNavDefinition[] = [
       {
         path: '/customers',
+        label: '顧客一覧',
+        description: '顧客アカウントを横断的に確認',
+        icon: FolderKanban,
+        params: { section: 'list' },
+      },
+      {
+        path: '/customers',
         label: 'コンテキスト',
         description: '顧客ポートフォリオの背景と注力領域',
         icon: Info,
@@ -696,6 +703,13 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
   const activeSection = sp?.get('section') ?? 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
+    {
+      path: '/customers',
+      label: '顧客一覧',
+      description: '他の顧客を参照',
+      icon: FolderKanban,
+      params: { section: 'list' },
+    },
     {
       path: '/customers',
       label: 'アカウント概要',
@@ -909,6 +923,13 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
     const navDefinitions: ModeNavDefinition[] = [
       {
         path: '/brands',
+        label: 'ブランド一覧',
+        description: 'ブランドポートフォリオを俯瞰',
+        icon: FolderKanban,
+        params: { section: 'list' },
+      },
+      {
+        path: '/brands',
         label: 'コンテキスト',
         description: 'ブランドポートフォリオの背景',
         icon: Info,
@@ -1057,6 +1078,13 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
   const activeSection = sp?.get('section') ?? 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
+    {
+      path: '/brands',
+      label: 'ブランド一覧',
+      description: '他のブランドを参照',
+      icon: FolderKanban,
+      params: { section: 'list' },
+    },
     {
       path: '/brands',
       label: 'ブランド概要',
@@ -1212,6 +1240,13 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
     const navDefinitions: ModeNavDefinition[] = [
       {
         path: '/programs',
+        label: 'プログラム一覧',
+        description: '全プログラムの状況を俯瞰',
+        icon: FolderKanban,
+        params: { section: 'list' },
+      },
+      {
+        path: '/programs',
         label: 'コンテキスト',
         description: 'ポートフォリオ全体の背景',
         icon: Info,
@@ -1360,6 +1395,13 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
   const activeSection = sp?.get('section') ?? 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
+    {
+      path: '/programs',
+      label: 'プログラム一覧',
+      description: '他のプログラムを参照',
+      icon: FolderKanban,
+      params: { section: 'list' },
+    },
     {
       path: '/programs',
       label: 'プログラム概要',

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -1,157 +1,310 @@
 'use client'
+
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import type { ReadonlyURLSearchParams } from 'next/navigation'
-import { ViewSwitch, useCurrentView, type ViewId } from '@/components/ViewSwitch'
 import { Breadcrumbs, Crumb } from '@/components/Breadcrumbs'
-import { BookOpenCheck, FolderKanban, Users2, Landmark, Layers, User, Database } from 'lucide-react'
 import { clsx } from 'clsx'
 import React from 'react'
+import {
+  BarChart3,
+  BookOpenCheck,
+  Database,
+  FilePenLine,
+  FolderKanban,
+  Landmark,
+  Layers,
+  Megaphone,
+  NotebookPen,
+  Sparkles,
+  User,
+  Users2,
+} from 'lucide-react'
+import { resolveViewHome, useCurrentView, VIEWS, type ViewId } from '@/components/ViewSwitch'
 
-type NavItem = { href: string; label: string; icon?: React.ComponentType<any> }
-
-function useNav(): { items: NavItem[] } {
-  const v = useCurrentView()
-  const items: Record<string, NavItem[]> = {
-    customer: [
-      { href: '/projects/my', label: 'Myプロジェクト', icon: FolderKanban },
-      { href: '/customers', label: '顧客一覧', icon: Users2 },
-    ],
-    brand: [
-      { href: '/projects/my', label: 'Myプロジェクト', icon: FolderKanban },
-      { href: '/brands', label: 'ブランド一覧', icon: Landmark },
-    ],
-    program: [
-      { href: '/projects/my', label: 'Myプロジェクト', icon: FolderKanban },
-      { href: '/programs', label: 'プログラム一覧', icon: Layers },
-    ],
-  }
-  return { items: items[v] }
+type ModeNavDefinition = {
+  path: string
+  label: string
+  description?: string
+  icon: React.ComponentType<any>
+  params?: Record<string, string>
 }
 
-const persistentItems: NavItem[] = [
-  { href: '/playbooks', label: 'プレイブック', icon: BookOpenCheck },
-  { href: '/datasources', label: 'データソース', icon: Database },
-]
+type ModeNavItem = ModeNavDefinition & {
+  href: string
+  isActive: boolean
+}
 
-function withView(href: string, sp: ReadonlyURLSearchParams | null, fallbackView: ViewId): string {
+type ModeOption = {
+  id: ViewId
+  label: string
+  icon: React.ComponentType<any>
+  href: string
+  isActive: boolean
+}
+
+const MODE_NAV_DEFINITIONS: Record<ViewId, ModeNavDefinition[]> = {
+  projects: [
+    {
+      path: '/projects/my',
+      label: 'Myプロジェクト',
+      description: '担当プロジェクトの状況を確認',
+      icon: FolderKanban,
+    },
+    {
+      path: '/projects/my',
+      label: 'レポート',
+      description: '最新の成果物と指標をチェック',
+      params: { section: 'reports' },
+      icon: BarChart3,
+    },
+  ],
+  customer: [
+    {
+      path: '/customers',
+      label: '顧客一覧',
+      description: '管理中の顧客アカウント',
+      icon: Users2,
+    },
+    {
+      path: '/customers',
+      label: 'ショートカット',
+      description: '重要な顧客ビューへ素早く移動',
+      params: { section: 'shortcuts' },
+      icon: Sparkles,
+    },
+  ],
+  brand: [
+    {
+      path: '/brands',
+      label: 'ブランド一覧',
+      description: 'ブランドプロファイルの管理',
+      icon: Landmark,
+    },
+    {
+      path: '/brands',
+      label: '関連キャンペーン',
+      description: 'ブランドに紐づくアクティビティ',
+      params: { section: 'campaigns' },
+      icon: Megaphone,
+    },
+  ],
+  program: [
+    {
+      path: '/programs',
+      label: 'プログラム一覧',
+      description: '進行中のプログラムを俯瞰',
+      icon: Layers,
+    },
+    {
+      path: '/programs',
+      label: 'テンプレート',
+      description: '再利用可能なプログラム設計',
+      params: { section: 'templates' },
+      icon: NotebookPen,
+    },
+  ],
+  playbook: [
+    {
+      path: '/playbooks',
+      label: 'プレイブック',
+      description: 'チームで共有する運用ナレッジ',
+      icon: BookOpenCheck,
+    },
+    {
+      path: '/playbooks',
+      label: '下書き',
+      description: '作成途中のプレイブック',
+      params: { section: 'drafts' },
+      icon: FilePenLine,
+    },
+  ],
+  settings: [
+    {
+      path: '/settings',
+      label: 'アカウント設定',
+      description: 'プロフィールや通知設定を管理',
+      icon: User,
+    },
+    {
+      path: '/datasources',
+      label: 'データソース',
+      description: '接続済みの外部データを管理',
+      icon: Database,
+    },
+  ],
+}
+
+const CONTROLLED_QUERY_KEYS = Array.from(
+  new Set(
+    Object.values(MODE_NAV_DEFINITIONS)
+      .flat()
+      .flatMap(def => Object.keys(def.params ?? {})),
+  ),
+)
+
+function createHrefWithView(
+  path: string,
+  sp: ReadonlyURLSearchParams | null,
+  view: ViewId,
+  extraParams?: Record<string, string>,
+): string {
   const params = new URLSearchParams(sp?.toString() || '')
-  if (!params.get('v')) params.set('v', fallbackView)
-  return `${href}?${params.toString()}`
+  CONTROLLED_QUERY_KEYS.forEach(key => {
+    if (!extraParams || !(key in extraParams)) {
+      params.delete(key)
+    }
+  })
+  params.set('v', view)
+  if (extraParams) {
+    Object.entries(extraParams).forEach(([key, value]) => {
+      params.set(key, value)
+    })
+  }
+  const query = params.toString()
+  return query ? `${path}?${query}` : `${path}`
 }
 
-export function Shell({ children, crumbs }: { children: React.ReactNode; crumbs?: Crumb[] }) {
+function buildModeOptions(
+  sp: ReadonlyURLSearchParams | null,
+  currentView: ViewId,
+): ModeOption[] {
+  return VIEWS.map(view => ({
+    id: view.id,
+    label: view.label,
+    icon: view.icon,
+    href: createHrefWithView(resolveViewHome(view.id), sp, view.id),
+    isActive: currentView === view.id,
+  }))
+}
+
+function buildModeNavItems(
+  definitions: ModeNavDefinition[],
+  sp: ReadonlyURLSearchParams | null,
+  currentView: ViewId,
+  pathname: string,
+): ModeNavItem[] {
+  return definitions.map(def => {
+    const href = createHrefWithView(def.path, sp, currentView, def.params)
+    const basePath = def.path
+    const matchesPath = pathname === basePath || pathname.startsWith(`${basePath}/`)
+    const matchesParams = def.params
+      ? Object.entries(def.params).every(([key, value]) => sp?.get(key) === value)
+      : true
+    const isActive = matchesPath && matchesParams
+    return { ...def, href, isActive }
+  })
+}
+
+function useNav() {
   const pathname = usePathname() || '/'
   const sp = useSearchParams()
   const currentView = useCurrentView()
-  const { items } = useNav()
+
+  const modeOptions = buildModeOptions(sp, currentView)
+  const subNavDefinitions = MODE_NAV_DEFINITIONS[currentView] ?? []
+  const items = buildModeNavItems(subNavDefinitions, sp, currentView, pathname)
+
+  return { modeOptions, items, currentView, isExpanded: items.length > 0 }
+}
+
+export function Shell({ children, crumbs }: { children: React.ReactNode; crumbs?: Crumb[] }) {
+  const { modeOptions, items, isExpanded } = useNav()
+  const activeMode = modeOptions.find(mode => mode.isActive)
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
-      {/* Left nav */}
-      <aside className="fixed inset-y-0 left-0 z-40 w-[244px] border-r border-slate-200 bg-white flex flex-col">
-        <div className="h-14 px-3 border-b border-slate-200 flex items-center gap-2">
-          <div className="h-8 w-8 rounded-2xl bg-indigo-600 text-white grid place-items-center font-bold">B</div>
-          <div className="font-semibold tracking-tight">Benten</div>
-        </div>
-        <nav className="flex-1 overflow-y-auto p-2">
-          {items.map(it => {
-            const Icon = it.icon || FolderKanban
-            const active = pathname.startsWith(it.href)
-            return (
-              <div key={it.href} className="mb-1">
+      <aside className="fixed inset-y-0 left-0 z-40 flex w-[320px] border-r border-slate-200 bg-white shadow-sm">
+        <div className="flex w-20 flex-col border-r border-slate-100 bg-white">
+          <div className="flex h-14 items-center justify-center border-b border-slate-100">
+            <div className="grid h-9 w-9 place-items-center rounded-2xl bg-indigo-600 font-semibold text-white">B</div>
+          </div>
+          <nav className="flex-1 space-y-3 py-4">
+            {modeOptions.map(option => {
+              const Icon = option.icon
+              return (
                 <Link
-                  href={withView(it.href, sp, currentView)}
-                  aria-current={active ? 'page' : undefined}
+                  key={option.id}
+                  href={option.href}
+                  aria-current={option.isActive ? 'page' : undefined}
                   className={clsx(
-                    'group flex items-center gap-3 rounded-xl px-3 py-2 font-medium text-slate-600 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
-                    active
-                      ? 'bg-indigo-50 text-indigo-700 shadow-sm'
-                      : 'hover:bg-indigo-50/70 hover:text-indigo-700',
+                    'mx-auto flex h-12 w-12 items-center justify-center rounded-2xl text-slate-500 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
+                    option.isActive
+                      ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-500/20'
+                      : 'bg-slate-100 hover:bg-indigo-100 hover:text-indigo-700',
                   )}
                 >
-                  <div
-                    className={clsx(
-                      'grid h-9 w-9 place-items-center rounded-xl transition-colors duration-150',
-                      active
-                        ? 'bg-indigo-600 text-white'
-                        : 'bg-slate-100 text-slate-600 group-hover:bg-indigo-100 group-hover:text-indigo-700',
-                    )}
-                  >
-                    <Icon className="w-4 h-4" />
-                  </div>
-                  <span>{it.label}</span>
+                  <Icon className="h-5 w-5" />
+                  <span className="sr-only">{option.label}</span>
                 </Link>
-              </div>
-            )
-          })}
-        </nav>
-        <div className="border-t border-slate-200 p-3 space-y-2">
-          {persistentItems.map(it => {
-            const Icon = it.icon || FolderKanban
-            const active = pathname.startsWith(it.href)
-            return (
-              <Link
-                key={it.href}
-                href={withView(it.href, sp, currentView)}
-                aria-current={active ? 'page' : undefined}
-                className={clsx(
-                  'group flex items-center gap-3 rounded-xl px-2 py-2 text-sm font-medium text-slate-600 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
-                  active
-                    ? 'bg-indigo-50 text-indigo-700 shadow-sm'
-                    : 'hover:bg-indigo-50/70 hover:text-indigo-700',
-                )}
-              >
-                <div
-                  className={clsx(
-                    'grid h-8 w-8 place-items-center rounded-xl transition-colors duration-150',
-                    active
-                      ? 'bg-indigo-600 text-white'
-                      : 'bg-slate-100 text-slate-600 group-hover:bg-indigo-100 group-hover:text-indigo-700',
-                  )}
-                >
-                  <Icon className="w-4 h-4" />
-                </div>
-                <span>{it.label}</span>
-              </Link>
-            )
-          })}
-          <Link
-            href={withView('/settings', sp, currentView)}
+              )
+            })}
+          </nav>
+        </div>
+        <div
+          className={clsx(
+            'flex flex-1 flex-col border-l border-slate-200 bg-white transition-[width] duration-300 ease-in-out',
+            isExpanded ? 'w-[240px]' : 'w-0',
+          )}
+        >
+          <div
             className={clsx(
-              'group flex items-center gap-3 rounded-xl px-2 py-2 text-sm font-medium text-slate-600 transition-colors duration-150 hover:bg-indigo-50/70 hover:text-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
-              pathname.startsWith('/settings') && 'bg-indigo-50 text-indigo-700 shadow-sm',
+              'flex h-full flex-col overflow-hidden transition-opacity duration-200',
+              isExpanded ? 'opacity-100' : 'pointer-events-none opacity-0',
             )}
           >
-            <div
-              className={clsx(
-                'grid h-8 w-8 place-items-center rounded-full transition-colors duration-150',
-                pathname.startsWith('/settings')
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-slate-200 text-slate-600 group-hover:bg-indigo-100 group-hover:text-indigo-700',
-              )}
-            >
-              <User
-                className={clsx(
-                  'w-4 h-4',
-                  pathname.startsWith('/settings') ? 'text-white' : undefined,
-                )}
-              />
+            <div className="border-b border-slate-100 px-4 py-4">
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">モード</div>
+              <div className="mt-1 text-lg font-semibold text-slate-800">{activeMode?.label}</div>
             </div>
-            <div className="flex-1">
-              <div className="text-sm font-medium">アカウント設定</div>
-              <div className="text-xs text-slate-500">Settings</div>
-            </div>
-          </Link>
+            <nav className="flex-1 space-y-2 overflow-y-auto px-3 py-4">
+              {items.map(item => {
+                const Icon = item.icon
+                const keySuffix = item.params
+                  ? Object.entries(item.params)
+                      .map(([k, v]) => `${k}:${v}`)
+                      .join('|')
+                  : 'root'
+                return (
+                  <Link
+                    key={`${item.path}-${keySuffix}`}
+                    href={item.href}
+                    aria-current={item.isActive ? 'page' : undefined}
+                    className={clsx(
+                      'group flex items-start gap-3 rounded-2xl px-3 py-3 text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
+                      item.isActive
+                        ? 'bg-indigo-50 text-indigo-700 shadow-sm'
+                        : 'text-slate-600 hover:bg-indigo-50/70 hover:text-indigo-700',
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        'mt-0.5 grid h-9 w-9 place-items-center rounded-xl border border-transparent bg-slate-100 text-slate-600 transition-colors duration-150',
+                        item.isActive
+                          ? 'border-indigo-100 bg-indigo-600 text-white shadow-sm'
+                          : 'group-hover:bg-indigo-100 group-hover:text-indigo-700',
+                      )}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </span>
+                    <span className="flex-1">
+                      <span className="block text-sm font-semibold leading-tight">{item.label}</span>
+                      {item.description ? (
+                        <span className="mt-1 block text-xs text-slate-500">{item.description}</span>
+                      ) : null}
+                    </span>
+                  </Link>
+                )
+              })}
+            </nav>
+          </div>
         </div>
       </aside>
 
-      {/* Header */}
-      <div className="ml-[244px] min-h-screen">
+      <div className="ml-[320px] min-h-screen">
         <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/80 backdrop-blur">
-          <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between gap-3">
+          <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
             <Breadcrumbs crumbs={crumbs} />
-            <ViewSwitch />
           </div>
         </header>
         <main className="mx-auto max-w-6xl px-4 py-6">{children}</main>

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -564,13 +564,6 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
     const navDefinitions: ModeNavDefinition[] = [
       {
         path: '/customers',
-        label: '顧客一覧',
-        description: 'アカウント全体をすばやく俯瞰',
-        icon: Users2,
-        params: { section: 'list' },
-      },
-      {
-        path: '/customers',
         label: 'コンテキスト',
         description: '顧客ポートフォリオの背景と注力領域',
         icon: Info,

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -3,24 +3,32 @@
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import type { ReadonlyURLSearchParams } from 'next/navigation'
-import { Breadcrumbs, Crumb } from '@/components/Breadcrumbs'
+import { Breadcrumbs, type Crumb } from '@/components/Breadcrumbs'
 import { clsx } from 'clsx'
 import React from 'react'
 import {
   BarChart3,
   BookOpenCheck,
+  CalendarClock,
+  Compass,
   Database,
   FilePenLine,
   FolderKanban,
   Landmark,
   Layers,
-  Megaphone,
-  NotebookPen,
   Sparkles,
+  Target,
   User,
   Users2,
 } from 'lucide-react'
 import { resolveViewHome, useCurrentView, VIEWS, type ViewId } from '@/components/ViewSwitch'
+
+const CONTROLLED_QUERY_KEYS = ['section', 'customerId', 'brandId', 'programId', 'focus'] as const
+
+const DEFAULT_MENU_WIDTH = 320
+const ICON_RAIL_WIDTH = 80
+
+type ControlledQueryKey = (typeof CONTROLLED_QUERY_KEYS)[number]
 
 type ModeNavDefinition = {
   path: string
@@ -43,7 +51,240 @@ type ModeOption = {
   isActive: boolean
 }
 
-const MODE_NAV_DEFINITIONS: Record<ViewId, ModeNavDefinition[]> = {
+type ContextEntry = {
+  label: string
+  value: string
+  meta?: string
+}
+
+type CollectionItem = {
+  id: string
+  label: string
+  meta?: string
+  status?: 'delivered' | 'active' | 'alert' | 'planning'
+  href?: string
+}
+
+type HierarchySection =
+  | {
+      type: 'navigation'
+      id: string
+      title: string
+      description?: string
+      items: ModeNavItem[]
+    }
+  | {
+      type: 'context'
+      id: string
+      title: string
+      entries: ContextEntry[]
+    }
+  | {
+      type: 'collection'
+      id: string
+      title: string
+      emptyText?: string
+      items: CollectionItem[]
+    }
+
+type HierarchyState = {
+  breadcrumbs: Crumb[]
+  sections: HierarchySection[]
+}
+
+type CustomerProgram = {
+  id: string
+  name: string
+  lead: string
+  status: string
+  currentSprint: string
+  deliverables: CollectionItem[]
+  communications: CollectionItem[]
+  strategies: CollectionItem[]
+}
+
+type CustomerBrand = {
+  id: string
+  name: string
+  mission: string
+  lead: string
+  health: string
+  healthMeta: string
+  keyMarkets: string
+  deliverables: CollectionItem[]
+  communications: CollectionItem[]
+  strategies: CollectionItem[]
+  programs: CustomerProgram[]
+}
+
+type CustomerAccount = {
+  id: string
+  name: string
+  owner: string
+  industry: string
+  region: string
+  health: string
+  healthMeta: string
+  deliverables: CollectionItem[]
+  communications: CollectionItem[]
+  strategies: CollectionItem[]
+  brands: CustomerBrand[]
+}
+
+const CUSTOMER_GRAPH: CustomerAccount[] = [
+  {
+    id: 'cust-001',
+    name: '株式会社エバーライト',
+    owner: '田中 未来',
+    industry: 'スマートライティング',
+    region: '東京',
+    health: '良好',
+    healthMeta: 'NRR 118% / ヘルススコア 8.7',
+    deliverables: [
+      { id: 'deliv-cust-1', label: 'Q2 エグゼクティブレビュー', meta: '提出済み・2024/06/20', status: 'delivered' },
+      { id: 'deliv-cust-2', label: 'オンボーディング改善ロードマップ', meta: 'レビュー待ち・2024/07/05', status: 'active' },
+    ],
+    communications: [
+      { id: 'comm-cust-1', label: '経営層定例ミーティング', meta: '次回 2024/07/12', status: 'active' },
+      { id: 'comm-cust-2', label: 'サクセスサマリーメール', meta: '送信済み 2024/06/18', status: 'delivered' },
+    ],
+    strategies: [
+      { id: 'strat-cust-1', label: 'LTV 最大化プラン FY2024', meta: 'フェーズ2・ROI 1.4x', status: 'active' },
+      { id: 'strat-cust-2', label: 'サポート自動化構想', meta: 'アイデア検証中', status: 'planning' },
+    ],
+    brands: [
+      {
+        id: 'brand-aurora',
+        name: 'Everlight Aurora',
+        mission: 'プレミアム向け IoT 照明ブランド',
+        lead: '佐藤 輝',
+        health: '注意',
+        healthMeta: 'キャンペーン ROI 64%',
+        keyMarkets: 'アジア・北米',
+        deliverables: [
+          { id: 'deliv-brand-1', label: 'Aurora ブランド診断レポート', meta: '提出済み・2024/06/05', status: 'delivered' },
+          { id: 'deliv-brand-2', label: '夏季キャンペーン提案書', meta: 'ドラフト・2024/07/08', status: 'active' },
+        ],
+        communications: [
+          { id: 'comm-brand-1', label: 'マーケチーム Slack チャンネル', meta: '未読 3 件', status: 'active' },
+          { id: 'comm-brand-2', label: 'Aurora 戦略ワークショップ', meta: '開催予定 2024/07/22', status: 'planning' },
+        ],
+        strategies: [
+          { id: 'strat-brand-1', label: '市場拡張 GTM プラン', meta: 'フェーズ1完了', status: 'active' },
+          { id: 'strat-brand-2', label: '高付加価値セグメント戦略', meta: 'レビュー待ち', status: 'active' },
+        ],
+        programs: [
+          {
+            id: 'prog-onboard',
+            name: 'オンボーディング改善プログラム',
+            lead: '藤井 昂',
+            status: '進行中',
+            currentSprint: 'Sprint 3 / 6',
+            deliverables: [
+              { id: 'deliv-prog-1', label: 'オンボーディング UX レポート', meta: 'レビュー待ち・2024/07/03', status: 'active' },
+              { id: 'deliv-prog-2', label: '新機能導入計画', meta: '準備中・2024/07/18', status: 'planning' },
+            ],
+            communications: [
+              { id: 'comm-prog-1', label: '週次スタンドアップ', meta: '次回 2024/07/04', status: 'active' },
+              { id: 'comm-prog-2', label: 'Aurora CX チャンネル', meta: '未読 1 件', status: 'active' },
+            ],
+            strategies: [
+              { id: 'strat-prog-1', label: 'エンゲージメント向上戦略', meta: '実行率 70%', status: 'active' },
+              { id: 'strat-prog-2', label: '契約更新タッチポイント整理', meta: 'ドラフト', status: 'planning' },
+            ],
+          },
+          {
+            id: 'prog-loyalty',
+            name: 'ロイヤリティ向上プログラム',
+            lead: '近藤 沙耶',
+            status: '計画中',
+            currentSprint: 'Kickoff 準備',
+            deliverables: [
+              { id: 'deliv-prog-3', label: 'ロイヤリティキャンバス', meta: '起案中', status: 'planning' },
+            ],
+            communications: [
+              { id: 'comm-prog-3', label: '準備タスクフォロー', meta: '担当 3 名', status: 'active' },
+            ],
+            strategies: [
+              { id: 'strat-prog-3', label: 'VIP 体験設計', meta: 'ヒアリング中', status: 'planning' },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'brand-lumen',
+        name: 'Lumen Street',
+        mission: '都市型スマート街灯のサブブランド',
+        lead: '原田 玲奈',
+        health: '良好',
+        healthMeta: '導入都市 26 / CSAT 4.6',
+        keyMarkets: '北米・欧州',
+        deliverables: [
+          { id: 'deliv-brand-3', label: '都市別導入レポート', meta: '提出済み・2024/06/11', status: 'delivered' },
+        ],
+        communications: [
+          { id: 'comm-brand-3', label: '都市連携 Slack', meta: '未読 5 件', status: 'active' },
+        ],
+        strategies: [
+          { id: 'strat-brand-3', label: '自治体連携強化プラン', meta: '意思決定待ち', status: 'planning' },
+        ],
+        programs: [
+          {
+            id: 'prog-expansion',
+            name: '北米拡張プログラム',
+            lead: '吉本 海斗',
+            status: '進行中',
+            currentSprint: 'Sprint 2 / 8',
+            deliverables: [
+              { id: 'deliv-prog-4', label: '拡張市場分析レポート', meta: 'ドラフト', status: 'active' },
+            ],
+            communications: [
+              { id: 'comm-prog-4', label: '州政府タッチポイント整理', meta: '最新 2024/06/26', status: 'active' },
+            ],
+            strategies: [
+              { id: 'strat-prog-4', label: '地域別導入戦略', meta: '合意済み 3/5 州', status: 'active' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cust-002',
+    name: 'Brighton Holdings',
+    owner: 'Michael Green',
+    industry: '不動産テック',
+    region: '大阪 / シンガポール',
+    health: '成長',
+    healthMeta: 'NRR 134% / Upsell 3 件',
+    deliverables: [
+      { id: 'deliv-cust-3', label: '導入成果レポート', meta: '提出済み・2024/06/15', status: 'delivered' },
+    ],
+    communications: [
+      { id: 'comm-cust-3', label: 'CS リレーションレター', meta: '送信済み 2024/06/19', status: 'delivered' },
+    ],
+    strategies: [
+      { id: 'strat-cust-3', label: 'APAC 拡大戦略', meta: '実行率 45%', status: 'active' },
+    ],
+    brands: [
+      {
+        id: 'brand-bright',
+        name: 'Bright Living',
+        mission: 'IoT リビング体験',
+        lead: 'Sophie Tan',
+        health: '良好',
+        healthMeta: 'CSAT 4.8',
+        keyMarkets: '東南アジア',
+        deliverables: [],
+        communications: [],
+        strategies: [],
+        programs: [],
+      },
+    ],
+  },
+]
+
+const MODE_NAV_FALLBACK: Record<ViewId, ModeNavDefinition[]> = {
   projects: [
     {
       path: '/projects/my',
@@ -59,51 +300,9 @@ const MODE_NAV_DEFINITIONS: Record<ViewId, ModeNavDefinition[]> = {
       icon: BarChart3,
     },
   ],
-  customer: [
-    {
-      path: '/customers',
-      label: '顧客一覧',
-      description: '管理中の顧客アカウント',
-      icon: Users2,
-    },
-    {
-      path: '/customers',
-      label: 'ショートカット',
-      description: '重要な顧客ビューへ素早く移動',
-      params: { section: 'shortcuts' },
-      icon: Sparkles,
-    },
-  ],
-  brand: [
-    {
-      path: '/brands',
-      label: 'ブランド一覧',
-      description: 'ブランドプロファイルの管理',
-      icon: Landmark,
-    },
-    {
-      path: '/brands',
-      label: '関連キャンペーン',
-      description: 'ブランドに紐づくアクティビティ',
-      params: { section: 'campaigns' },
-      icon: Megaphone,
-    },
-  ],
-  program: [
-    {
-      path: '/programs',
-      label: 'プログラム一覧',
-      description: '進行中のプログラムを俯瞰',
-      icon: Layers,
-    },
-    {
-      path: '/programs',
-      label: 'テンプレート',
-      description: '再利用可能なプログラム設計',
-      params: { section: 'templates' },
-      icon: NotebookPen,
-    },
-  ],
+  customer: [],
+  brand: [],
+  program: [],
   playbook: [
     {
       path: '/playbooks',
@@ -135,22 +334,18 @@ const MODE_NAV_DEFINITIONS: Record<ViewId, ModeNavDefinition[]> = {
   ],
 }
 
-const CONTROLLED_QUERY_KEYS = Array.from(
-  new Set(
-    Object.values(MODE_NAV_DEFINITIONS)
-      .flat()
-      .flatMap(def => Object.keys(def.params ?? {})),
-  ),
-)
-
 function createHrefWithView(
   path: string,
   sp: ReadonlyURLSearchParams | null,
   view: ViewId,
   extraParams?: Record<string, string>,
+  options?: { preserve?: ControlledQueryKey[] },
 ): string {
   const params = new URLSearchParams(sp?.toString() || '')
   CONTROLLED_QUERY_KEYS.forEach(key => {
+    if (options?.preserve?.includes(key)) {
+      return
+    }
     if (!extraParams || !(key in extraParams)) {
       params.delete(key)
     }
@@ -158,17 +353,18 @@ function createHrefWithView(
   params.set('v', view)
   if (extraParams) {
     Object.entries(extraParams).forEach(([key, value]) => {
-      params.set(key, value)
+      if (value === '') {
+        params.delete(key)
+      } else {
+        params.set(key, value)
+      }
     })
   }
   const query = params.toString()
   return query ? `${path}?${query}` : `${path}`
 }
 
-function buildModeOptions(
-  sp: ReadonlyURLSearchParams | null,
-  currentView: ViewId,
-): ModeOption[] {
+function buildModeOptions(sp: ReadonlyURLSearchParams | null, currentView: ViewId): ModeOption[] {
   return VIEWS.map(view => ({
     id: view.id,
     label: view.label,
@@ -196,25 +392,498 @@ function buildModeNavItems(
   })
 }
 
-function useNav() {
+function statusStyles(status?: CollectionItem['status']) {
+  switch (status) {
+    case 'delivered':
+      return 'bg-emerald-50 text-emerald-700 border border-emerald-100'
+    case 'alert':
+      return 'bg-rose-50 text-rose-700 border border-rose-100'
+    case 'planning':
+      return 'bg-sky-50 text-sky-700 border border-sky-100'
+    case 'active':
+    default:
+      return 'bg-indigo-50 text-indigo-700 border border-indigo-100'
+  }
+}
+
+
+type BuilderArgs = {
+  sp: ReadonlyURLSearchParams | null
+  currentView: ViewId
+  pathname: string
+}
+
+type HierarchyBuilder = (args: BuilderArgs) => HierarchyState
+
+function buildFallbackHierarchy(definitions: ModeNavDefinition[]): HierarchyBuilder {
+  return ({ sp, currentView, pathname }) => {
+    const items = buildModeNavItems(definitions, sp, currentView, pathname)
+    return {
+      breadcrumbs: definitions.length
+        ? [
+            {
+              href: createHrefWithView(definitions[0].path, sp, currentView),
+              label: VIEWS.find(view => view.id === currentView)?.label ?? 'メニュー',
+            },
+          ]
+        : [],
+      sections: items.length
+        ? [
+            {
+              type: 'navigation',
+              id: `${currentView}-nav`,
+              title: 'メニュー',
+              items,
+            },
+          ]
+        : [],
+    }
+  }
+}
+
+function pickCustomer(sp: ReadonlyURLSearchParams | null) {
+  const requestedId = sp?.get('customerId')
+  const customer = CUSTOMER_GRAPH.find(account => account.id === requestedId) ?? CUSTOMER_GRAPH[0]
+  return customer
+}
+
+function findBrand(customer: CustomerAccount, sp: ReadonlyURLSearchParams | null) {
+  const requestedId = sp?.get('brandId')
+  if (!requestedId) return null
+  return customer.brands.find(brand => brand.id === requestedId) ?? null
+}
+
+function findProgram(brand: CustomerBrand | null, sp: ReadonlyURLSearchParams | null) {
+  if (!brand) return null
+  const requestedId = sp?.get('programId')
+  if (!requestedId) return null
+  return brand.programs.find(program => program.id === requestedId) ?? null
+}
+
+function createContextSection(
+  customer: CustomerAccount,
+  brand: CustomerBrand | null,
+  program: CustomerProgram | null,
+): ContextEntry[] {
+  const entries: ContextEntry[] = [
+    { label: 'アカウントオーナー', value: customer.owner },
+    { label: '業種', value: customer.industry },
+    { label: '主要拠点', value: customer.region },
+    { label: 'アカウントヘルス', value: customer.health, meta: customer.healthMeta },
+  ]
+  if (brand) {
+    entries.push(
+      { label: 'ブランドリード', value: brand.lead },
+      { label: 'ブランドヘルス', value: brand.health, meta: brand.healthMeta },
+      { label: '注力市場', value: brand.keyMarkets },
+    )
+  }
+  if (program) {
+    entries.push(
+      { label: 'プログラムオーナー', value: program.lead },
+      { label: '現在の進捗', value: program.status, meta: program.currentSprint },
+    )
+  }
+  return entries
+}
+
+function attachCollection(
+  customer: CustomerAccount,
+  brand: CustomerBrand | null,
+  program: CustomerProgram | null,
+  key: 'deliverables' | 'communications' | 'strategies',
+): CollectionItem[] {
+  if (program && program[key].length) {
+    return program[key]
+  }
+  if (brand && brand[key].length) {
+    return brand[key]
+  }
+  return customer[key]
+}
+function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): HierarchyState {
+  const customer = pickCustomer(sp)
+  const brand = findBrand(customer, sp)
+  const program = findProgram(brand, sp)
+
+  const navDefinitions: ModeNavDefinition[] = []
+
+  navDefinitions.push(
+    {
+      path: '/customers',
+      label: 'アカウント概要',
+      description: '収益・契約・サクセス指標を俯瞰',
+      icon: Users2,
+      params: { section: 'overview', customerId: customer.id },
+    },
+    {
+      path: '/customers',
+      label: '関係者マップ',
+      description: '主要ステークホルダーの関係性を整理',
+      icon: Sparkles,
+      params: { section: 'stakeholders', customerId: customer.id },
+    },
+  )
+
+  if (brand) {
+    navDefinitions.push({
+      path: '/customers',
+      label: `${brand.name} ブランド`,
+      description: 'ブランドの体験と成果を整理',
+      icon: Landmark,
+      params: { section: 'brand-overview', customerId: customer.id, brandId: brand.id },
+    })
+  }
+
+  if (program) {
+    navDefinitions.push({
+      path: '/customers',
+      label: `${program.name}`,
+      description: 'スプリント成果とロードマップ',
+      icon: Layers,
+      params: {
+        section: 'program-overview',
+        customerId: customer.id,
+        brandId: brand?.id ?? '',
+        programId: program.id,
+      },
+    })
+  }
+
+  const items = buildModeNavItems(navDefinitions, sp, currentView, pathname)
+
+  const breadcrumbs: Crumb[] = [
+    { href: createHrefWithView('/customers', sp, 'customer'), label: '顧客' },
+    {
+      href: createHrefWithView(
+        '/customers',
+        sp,
+        'customer',
+        { customerId: customer.id },
+        { preserve: ['customerId'] },
+      ),
+      label: customer.name,
+    },
+  ]
+
+  if (brand) {
+    breadcrumbs.push({
+      href: createHrefWithView(
+        '/customers',
+        sp,
+        'customer',
+        { customerId: customer.id, brandId: brand.id },
+        { preserve: ['customerId', 'brandId'] },
+      ),
+      label: brand.name,
+    })
+  }
+
+  if (brand && program) {
+    breadcrumbs.push({
+      href: createHrefWithView(
+        '/customers',
+        sp,
+        'customer',
+        {
+          customerId: customer.id,
+          brandId: brand.id,
+          programId: program.id,
+        },
+        { preserve: ['customerId', 'brandId', 'programId'] },
+      ),
+      label: program.name,
+    })
+  }
+
+  const sections: HierarchySection[] = []
+  if (items.length) {
+    sections.push({
+      type: 'navigation',
+      id: 'customer-navigation',
+      title: brand ? `${brand.name} のナビゲーション` : `${customer.name} のナビゲーション`,
+      description: program ? `${program.name} にフォーカスしています` : undefined,
+      items,
+    })
+  }
+
+  const contextEntries = createContextSection(customer, brand, program)
+  sections.push({ type: 'context', id: 'customer-context', title: 'コンテキスト', entries: contextEntries })
+
+  const deliverables = attachCollection(customer, brand, program, 'deliverables')
+  const communications = attachCollection(customer, brand, program, 'communications')
+  const strategies = attachCollection(customer, brand, program, 'strategies')
+
+  sections.push({
+    type: 'collection',
+    id: 'customer-deliverables',
+    title: '成果物',
+    emptyText: '成果物はまだ登録されていません',
+    items: deliverables,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'customer-communications',
+    title: 'コミュニケーション',
+    emptyText: '関連するコミュニケーションはまだありません',
+    items: communications,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'customer-strategies',
+    title: '戦略',
+    emptyText: '戦略ドキュメントはまだ登録されていません',
+    items: strategies,
+  })
+
+  return { breadcrumbs, sections }
+}
+function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): HierarchyState {
+  const allBrands: Array<{ customer: CustomerAccount; brand: CustomerBrand }> = []
+  CUSTOMER_GRAPH.forEach(customer => {
+    customer.brands.forEach(brand => {
+      allBrands.push({ customer, brand })
+    })
+  })
+
+  const requestedBrandId = sp?.get('brandId')
+  const fallback = allBrands[0]
+  const active = allBrands.find(entry => entry.brand.id === requestedBrandId) ?? fallback
+  const { customer, brand } = active
+
+  const navDefinitions: ModeNavDefinition[] = [
+    {
+      path: '/brands',
+      label: 'ブランド概要',
+      description: '市場ポジションと KPI を確認',
+      icon: Landmark,
+      params: { brandId: brand.id, section: 'overview' },
+    },
+    {
+      path: '/brands',
+      label: '体験マップ',
+      description: 'チャネル横断の体験ジャーニー',
+      icon: Compass,
+      params: { brandId: brand.id, section: 'journey' },
+    },
+  ]
+
+  if (brand.programs.length) {
+    navDefinitions.push({
+      path: '/brands',
+      label: '関連プログラム',
+      description: '進行中のプログラムと成果',
+      icon: Layers,
+      params: { brandId: brand.id, section: 'programs' },
+    })
+  }
+
+  const items = buildModeNavItems(navDefinitions, sp, currentView, pathname)
+
+  const breadcrumbs: Crumb[] = [
+    { href: createHrefWithView('/brands', sp, 'brand'), label: 'ブランド' },
+    {
+      href: createHrefWithView(
+        '/brands',
+        sp,
+        'brand',
+        { brandId: brand.id },
+        { preserve: ['brandId'] },
+      ),
+      label: brand.name,
+    },
+  ]
+
+  const sections: HierarchySection[] = []
+  if (items.length) {
+    sections.push({
+      type: 'navigation',
+      id: 'brand-navigation',
+      title: `${brand.name} のメニュー`,
+      description: `${customer.name} アカウントより`,
+      items,
+    })
+  }
+
+  const contextEntries: ContextEntry[] = [
+    { label: 'ブランドリード', value: brand.lead },
+    { label: '親アカウント', value: customer.name },
+    { label: 'ブランドヘルス', value: brand.health, meta: brand.healthMeta },
+    { label: '注力市場', value: brand.keyMarkets },
+  ]
+
+  sections.push({ type: 'context', id: 'brand-context', title: 'コンテキスト', entries: contextEntries })
+
+  sections.push({
+    type: 'collection',
+    id: 'brand-deliverables',
+    title: '成果物',
+    emptyText: 'ブランドに紐づく成果物はまだありません',
+    items: brand.deliverables,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'brand-communications',
+    title: 'コミュニケーション',
+    emptyText: '共有チャネルはまだありません',
+    items: brand.communications,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'brand-strategies',
+    title: '戦略',
+    emptyText: '戦略はまだ登録されていません',
+    items: brand.strategies,
+  })
+
+  return { breadcrumbs, sections }
+}
+function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): HierarchyState {
+  const allPrograms: Array<{ customer: CustomerAccount; brand: CustomerBrand; program: CustomerProgram }> = []
+  CUSTOMER_GRAPH.forEach(customer => {
+    customer.brands.forEach(brand => {
+      brand.programs.forEach(program => {
+        allPrograms.push({ customer, brand, program })
+      })
+    })
+  })
+
+  const requestedProgramId = sp?.get('programId')
+  const fallback = allPrograms[0]
+  const active = allPrograms.find(entry => entry.program.id === requestedProgramId) ?? fallback
+  const { customer, brand, program } = active
+
+  const navDefinitions: ModeNavDefinition[] = [
+    {
+      path: '/programs',
+      label: 'プログラム概要',
+      description: '目的・成果とガバナンス',
+      icon: Layers,
+      params: { programId: program.id, section: 'overview' },
+    },
+    {
+      path: '/programs',
+      label: 'スプリント計画',
+      description: '進行中のタスクとマイルストーン',
+      icon: CalendarClock,
+      params: { programId: program.id, section: 'sprints' },
+    },
+    {
+      path: '/programs',
+      label: 'リスクと依存関係',
+      description: 'リスクログと依存解消の進捗',
+      icon: Target,
+      params: { programId: program.id, section: 'risks' },
+    },
+  ]
+
+  const items = buildModeNavItems(navDefinitions, sp, currentView, pathname)
+
+  const breadcrumbs: Crumb[] = [
+    { href: createHrefWithView('/programs', sp, 'program'), label: 'プログラム' },
+    {
+      href: createHrefWithView(
+        '/programs',
+        sp,
+        'program',
+        { programId: program.id },
+        { preserve: ['programId'] },
+      ),
+      label: program.name,
+    },
+  ]
+
+  const sections: HierarchySection[] = []
+  if (items.length) {
+    sections.push({
+      type: 'navigation',
+      id: 'program-navigation',
+      title: `${program.name} のメニュー`,
+      description: `${brand.name} / ${customer.name}`,
+      items,
+    })
+  }
+
+  const contextEntries: ContextEntry[] = [
+    { label: 'プログラムオーナー', value: program.lead },
+    { label: '親ブランド', value: brand.name },
+    { label: '親アカウント', value: customer.name },
+    { label: '現在の進捗', value: program.status, meta: program.currentSprint },
+  ]
+
+  sections.push({ type: 'context', id: 'program-context', title: 'コンテキスト', entries: contextEntries })
+
+  sections.push({
+    type: 'collection',
+    id: 'program-deliverables',
+    title: '成果物',
+    emptyText: '成果物はまだ登録されていません',
+    items: program.deliverables,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'program-communications',
+    title: 'コミュニケーション',
+    emptyText: '関連するコミュニケーションはまだありません',
+    items: program.communications,
+  })
+  sections.push({
+    type: 'collection',
+    id: 'program-strategies',
+    title: '戦略',
+    emptyText: '戦略ドキュメントはまだ登録されていません',
+    items: program.strategies,
+  })
+
+  return { breadcrumbs, sections }
+}
+const HIERARCHY_BUILDERS: Record<ViewId, HierarchyBuilder> = {
+  projects: buildFallbackHierarchy(MODE_NAV_FALLBACK.projects),
+  customer: buildCustomerHierarchy,
+  brand: buildBrandHierarchy,
+  program: buildProgramHierarchy,
+  playbook: buildFallbackHierarchy(MODE_NAV_FALLBACK.playbook),
+  settings: buildFallbackHierarchy(MODE_NAV_FALLBACK.settings),
+}
+
+function useNav(crumbsFromProps?: Crumb[]) {
   const pathname = usePathname() || '/'
   const sp = useSearchParams()
   const currentView = useCurrentView()
 
   const modeOptions = buildModeOptions(sp, currentView)
-  const subNavDefinitions = MODE_NAV_DEFINITIONS[currentView] ?? []
-  const items = buildModeNavItems(subNavDefinitions, sp, currentView, pathname)
+  const builder = HIERARCHY_BUILDERS[currentView] ?? buildFallbackHierarchy([])
+  const hierarchy = builder({ sp, currentView, pathname })
+  const breadcrumbs = hierarchy.breadcrumbs.length ? hierarchy.breadcrumbs : crumbsFromProps ?? []
+  const hasMenu = hierarchy.sections.length > 0
 
-  return { modeOptions, items, currentView, isExpanded: items.length > 0 }
+  return { modeOptions, sections: hierarchy.sections, breadcrumbs, hasMenu }
+}
+
+function statusLabel(status?: CollectionItem['status']) {
+  switch (status) {
+    case 'delivered':
+      return '提出済み'
+    case 'alert':
+      return 'アラート'
+    case 'planning':
+      return '計画中'
+    case 'active':
+    default:
+      return '進行中'
+  }
 }
 
 export function Shell({ children, crumbs }: { children: React.ReactNode; crumbs?: Crumb[] }) {
-  const { modeOptions, items, isExpanded } = useNav()
-  const activeMode = modeOptions.find(mode => mode.isActive)
+  const { modeOptions, sections, breadcrumbs, hasMenu } = useNav(crumbs)
+  const totalRailWidth = ICON_RAIL_WIDTH + (hasMenu ? DEFAULT_MENU_WIDTH : 0)
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
-      <aside className="fixed inset-y-0 left-0 z-40 flex w-[320px] border-r border-slate-200 bg-white shadow-sm">
+      <aside
+        className="fixed inset-y-0 left-0 z-40 flex border-r border-slate-200 bg-white shadow-sm"
+        style={{ width: totalRailWidth }}
+      >
         <div className="flex w-20 flex-col border-r border-slate-100 bg-white">
           <div className="flex h-14 items-center justify-center border-b border-slate-100">
             <div className="grid h-9 w-9 place-items-center rounded-2xl bg-indigo-600 font-semibold text-white">B</div>
@@ -243,71 +912,150 @@ export function Shell({ children, crumbs }: { children: React.ReactNode; crumbs?
         </div>
         <div
           className={clsx(
-            'flex flex-1 flex-col border-l border-slate-200 bg-white transition-[width] duration-300 ease-in-out',
-            isExpanded ? 'w-[240px]' : 'w-0',
+            'flex h-full flex-1 flex-col transition-opacity duration-200',
+            hasMenu ? 'opacity-100' : 'pointer-events-none opacity-0',
           )}
+          style={{ width: hasMenu ? DEFAULT_MENU_WIDTH : 0 }}
         >
-          <div
-            className={clsx(
-              'flex h-full flex-col overflow-hidden transition-opacity duration-200',
-              isExpanded ? 'opacity-100' : 'pointer-events-none opacity-0',
-            )}
-          >
-            <div className="border-b border-slate-100 px-4 py-4">
-              <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">モード</div>
-              <div className="mt-1 text-lg font-semibold text-slate-800">{activeMode?.label}</div>
+          <div className="flex h-full flex-col overflow-hidden border-l border-slate-100 bg-white">
+            <div className="border-b border-slate-100 px-5 py-4">
+              <Breadcrumbs crumbs={breadcrumbs} />
             </div>
-            <nav className="flex-1 space-y-2 overflow-y-auto px-3 py-4">
-              {items.map(item => {
-                const Icon = item.icon
-                const keySuffix = item.params
-                  ? Object.entries(item.params)
-                      .map(([k, v]) => `${k}:${v}`)
-                      .join('|')
-                  : 'root'
-                return (
-                  <Link
-                    key={`${item.path}-${keySuffix}`}
-                    href={item.href}
-                    aria-current={item.isActive ? 'page' : undefined}
-                    className={clsx(
-                      'group flex items-start gap-3 rounded-2xl px-3 py-3 text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
-                      item.isActive
-                        ? 'bg-indigo-50 text-indigo-700 shadow-sm'
-                        : 'text-slate-600 hover:bg-indigo-50/70 hover:text-indigo-700',
-                    )}
-                  >
-                    <span
-                      className={clsx(
-                        'mt-0.5 grid h-9 w-9 place-items-center rounded-xl border border-transparent bg-slate-100 text-slate-600 transition-colors duration-150',
-                        item.isActive
-                          ? 'border-indigo-100 bg-indigo-600 text-white shadow-sm'
-                          : 'group-hover:bg-indigo-100 group-hover:text-indigo-700',
+            <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
+              {sections.map(section => {
+                if (section.type === 'navigation') {
+                  return (
+                    <section key={section.id} className="space-y-3">
+                      <div className="space-y-1">
+                        <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{section.title}</h2>
+                        {section.description ? (
+                          <p className="text-sm text-slate-600">{section.description}</p>
+                        ) : null}
+                      </div>
+                      <div className="space-y-2">
+                        {section.items.map(item => {
+                          const Icon = item.icon
+                          const keySuffix = item.params
+                            ? Object.entries(item.params)
+                                .map(([k, v]) => `${k}:${v}`)
+                                .join('|')
+                            : 'root'
+                          return (
+                            <Link
+                              key={`${item.path}-${keySuffix}`}
+                              href={item.href}
+                              aria-current={item.isActive ? 'page' : undefined}
+                              className={clsx(
+                                'group flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3 text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200',
+                                item.isActive
+                                  ? 'border-indigo-200 bg-indigo-50 text-indigo-700 shadow-sm'
+                                  : 'hover:border-indigo-200 hover:bg-indigo-50/70 hover:text-indigo-700',
+                              )}
+                            >
+                              <span
+                                className={clsx(
+                                  'mt-0.5 grid h-9 w-9 place-items-center rounded-xl border border-transparent bg-slate-100 text-slate-600 transition-colors duration-150',
+                                  item.isActive
+                                    ? 'border-indigo-200 bg-indigo-600 text-white shadow-sm'
+                                    : 'group-hover:bg-indigo-100 group-hover:text-indigo-700',
+                                )}
+                              >
+                                <Icon className="h-4 w-4" />
+                              </span>
+                              <span className="flex-1">
+                                <span className="block text-sm font-semibold leading-tight">{item.label}</span>
+                                {item.description ? (
+                                  <span className="mt-1 block text-xs text-slate-500">{item.description}</span>
+                                ) : null}
+                              </span>
+                            </Link>
+                          )
+                        })}
+                      </div>
+                    </section>
+                  )
+                }
+
+                if (section.type === 'context') {
+                  return (
+                    <section key={section.id} className="space-y-3">
+                      <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{section.title}</h2>
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50">
+                        <dl className="divide-y divide-slate-200">
+                          {section.entries.map(entry => (
+                            <div key={`${entry.label}-${entry.value}`} className="flex flex-col gap-1 px-4 py-3">
+                              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">{entry.label}</dt>
+                              <dd className="text-sm font-medium text-slate-800">{entry.value}</dd>
+                              {entry.meta ? (
+                                <dd className="text-xs text-slate-500">{entry.meta}</dd>
+                              ) : null}
+                            </div>
+                          ))}
+                        </dl>
+                      </div>
+                    </section>
+                  )
+                }
+
+                if (section.type === 'collection') {
+                  return (
+                    <section key={section.id} className="space-y-3">
+                      <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">{section.title}</h2>
+                      {section.items.length ? (
+                        <ul className="space-y-2">
+                          {section.items.map(item => {
+                            const content = (
+                              <div className="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 transition-colors duration-150 group-hover:border-indigo-200 group-hover:bg-indigo-50/40">
+                                <div className="flex items-start justify-between gap-3">
+                                  <div>
+                                    <p className="text-sm font-semibold text-slate-800">{item.label}</p>
+                                    {item.meta ? <p className="text-xs text-slate-500">{item.meta}</p> : null}
+                                  </div>
+                                  {item.status ? (
+                                    <span
+                                      className={clsx(
+                                        'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                                        statusStyles(item.status),
+                                      )}
+                                    >
+                                      {statusLabel(item.status)}
+                                    </span>
+                                  ) : null}
+                                </div>
+                              </div>
+                            )
+
+                            if (item.href) {
+                              return (
+                                <li key={item.id}>
+                                  <Link
+                                    href={item.href}
+                                    className="group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200"
+                                  >
+                                    {content}
+                                  </Link>
+                                </li>
+                              )
+                            }
+
+                            return <li key={item.id}>{content}</li>
+                          })}
+                        </ul>
+                      ) : (
+                        <p className="text-xs text-slate-500">{section.emptyText}</p>
                       )}
-                    >
-                      <Icon className="h-4 w-4" />
-                    </span>
-                    <span className="flex-1">
-                      <span className="block text-sm font-semibold leading-tight">{item.label}</span>
-                      {item.description ? (
-                        <span className="mt-1 block text-xs text-slate-500">{item.description}</span>
-                      ) : null}
-                    </span>
-                  </Link>
-                )
+                    </section>
+                  )
+                }
+
+                return null
               })}
-            </nav>
+            </div>
           </div>
         </div>
       </aside>
-
-      <div className="ml-[320px] min-h-screen">
-        <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/80 backdrop-blur">
-          <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
-            <Breadcrumbs crumbs={crumbs} />
-          </div>
-        </header>
-        <main className="mx-auto max-w-6xl px-4 py-6">{children}</main>
+      <div className="min-h-screen" style={{ marginLeft: totalRailWidth }}>
+        <main className="mx-auto max-w-6xl px-6 py-8">{children}</main>
       </div>
     </div>
   )

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -564,6 +564,13 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
     const navDefinitions: ModeNavDefinition[] = [
       {
         path: '/customers',
+        label: '顧客一覧',
+        description: '登録済み顧客を俯瞰',
+        icon: Users2,
+        params: { section: 'list' },
+      },
+      {
+        path: '/customers',
         label: 'コンテキスト',
         description: '顧客ポートフォリオの背景と注力領域',
         icon: Info,
@@ -614,26 +621,6 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
         items,
       })
     }
-
-    const listItems: CollectionItem[] = CUSTOMER_GRAPH.map(account => ({
-      id: account.id,
-      label: account.name,
-      meta: `${account.industry} / ${account.region}`,
-      status: 'active',
-      href: createHrefWithView('/customers', sp, 'customer', {
-        customerId: account.id,
-        section: 'overview',
-      }),
-    }))
-
-    sections.push({
-      type: 'collection',
-      id: 'customer-portfolio-list',
-      title: '顧客一覧',
-      sectionKey: 'list',
-      emptyText: '顧客がまだ登録されていません',
-      items: listItems,
-    })
 
     const portfolioContext: ContextEntry[] = [
       { label: '総アカウント数', value: `${CUSTOMER_GRAPH.length}社` },
@@ -981,28 +968,6 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
       })
     }
 
-    const listItems: CollectionItem[] = allBrands.map(({ customer, brand }) => ({
-      id: brand.id,
-      label: brand.name,
-      meta: `${customer.name} / ${brand.keyMarkets}`,
-      status: brand.health === '注意' ? 'alert' : 'active',
-      href: createHrefWithView(
-        '/brands',
-        sp,
-        'brand',
-        { brandId: brand.id, section: 'overview' },
-      ),
-    }))
-
-    sections.push({
-      type: 'collection',
-      id: 'brand-portfolio-list',
-      title: 'ブランド一覧',
-      sectionKey: 'list',
-      emptyText: 'ブランドがまだ登録されていません',
-      items: listItems,
-    })
-
     const relatedCustomers = new Set(allBrands.map(entry => entry.customer.id)).size
     const activePrograms = allBrands.reduce((total, entry) => total + entry.brand.programs.length, 0)
     const attentionBrands = allBrands.filter(entry => entry.brand.health === '注意').length
@@ -1311,28 +1276,6 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
         items,
       })
     }
-
-    const listItems: CollectionItem[] = allPrograms.map(({ customer, brand, program }) => ({
-      id: program.id,
-      label: program.name,
-      meta: `${brand.name} / ${customer.name}`,
-      status: program.status.includes('計画') ? 'planning' : 'active',
-      href: createHrefWithView(
-        '/programs',
-        sp,
-        'program',
-        { programId: program.id, section: 'overview' },
-      ),
-    }))
-
-    sections.push({
-      type: 'collection',
-      id: 'program-portfolio-list',
-      title: 'プログラム一覧',
-      sectionKey: 'list',
-      emptyText: 'プログラムがまだ登録されていません',
-      items: listItems,
-    })
 
     const totalBrands = new Set(allPrograms.map(entry => entry.brand.id)).size
     const totalCustomers = new Set(allPrograms.map(entry => entry.customer.id)).size

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -700,16 +700,10 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
 
   const brand = findBrand(customer, sp, pathname)
   const program = findProgram(brand, sp, pathname)
-  const activeSection = sp?.get('section') ?? 'context'
+  const requestedSection = sp?.get('section')
+  const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
-    {
-      path: '/customers',
-      label: '顧客一覧',
-      description: '他の顧客を参照',
-      icon: FolderKanban,
-      params: { section: 'list' },
-    },
     {
       path: '/customers',
       label: 'アカウント概要',
@@ -1075,16 +1069,10 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
   }
 
   const { customer, brand } = active
-  const activeSection = sp?.get('section') ?? 'context'
+  const requestedSection = sp?.get('section')
+  const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
-    {
-      path: '/brands',
-      label: 'ブランド一覧',
-      description: '他のブランドを参照',
-      icon: FolderKanban,
-      params: { section: 'list' },
-    },
     {
       path: '/brands',
       label: 'ブランド概要',
@@ -1392,16 +1380,10 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
   }
 
   const { customer, brand, program } = active
-  const activeSection = sp?.get('section') ?? 'context'
+  const requestedSection = sp?.get('section')
+  const activeSection = requestedSection && requestedSection !== 'list' ? requestedSection : 'context'
 
   const navDefinitions: ModeNavDefinition[] = [
-    {
-      path: '/programs',
-      label: 'プログラム一覧',
-      description: '他のプログラムを参照',
-      icon: FolderKanban,
-      params: { section: 'list' },
-    },
     {
       path: '/programs',
       label: 'プログラム概要',

--- a/components/Shell.tsx
+++ b/components/Shell.tsx
@@ -156,16 +156,16 @@ type CustomerAccount = {
 
 const CUSTOMER_GRAPH: CustomerAccount[] = [
   {
-    id: 'cust-001',
-    name: '株式会社エバーライト',
+    id: 'cust-global-retail',
+    name: 'A社（Global Retail Inc.）',
     owner: '田中 未来',
-    industry: 'スマートライティング',
-    region: '東京',
+    industry: '小売 / オムニチャネル',
+    region: '東京 / 北米',
     health: '良好',
     healthMeta: 'NRR 118% / ヘルススコア 8.7',
     deliverables: [
       { id: 'deliv-cust-1', label: 'Q2 エグゼクティブレビュー', meta: '提出済み・2024/06/20', status: 'delivered' },
-      { id: 'deliv-cust-2', label: 'オンボーディング改善ロードマップ', meta: 'レビュー待ち・2024/07/05', status: 'active' },
+      { id: 'deliv-cust-2', label: 'オムニチャネル改善ロードマップ', meta: 'レビュー待ち・2024/07/05', status: 'active' },
     ],
     communications: [
       { id: 'comm-cust-1', label: '経営層定例ミーティング', meta: '次回 2024/07/12', status: 'active' },
@@ -177,20 +177,20 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
     ],
     brands: [
       {
-        id: 'brand-aurora',
-        name: 'Everlight Aurora',
-        mission: 'プレミアム向け IoT 照明ブランド',
+        id: 'brand-shoestore',
+        name: 'ShoeStore',
+        mission: '都市型スニーカーブランド',
         lead: '佐藤 輝',
         health: '注意',
         healthMeta: 'キャンペーン ROI 64%',
         keyMarkets: 'アジア・北米',
         deliverables: [
-          { id: 'deliv-brand-1', label: 'Aurora ブランド診断レポート', meta: '提出済み・2024/06/05', status: 'delivered' },
+          { id: 'deliv-brand-1', label: 'ShoeStore ブランド診断レポート', meta: '提出済み・2024/06/05', status: 'delivered' },
           { id: 'deliv-brand-2', label: '夏季キャンペーン提案書', meta: 'ドラフト・2024/07/08', status: 'active' },
         ],
         communications: [
           { id: 'comm-brand-1', label: 'マーケチーム Slack チャンネル', meta: '未読 3 件', status: 'active' },
-          { id: 'comm-brand-2', label: 'Aurora 戦略ワークショップ', meta: '開催予定 2024/07/22', status: 'planning' },
+          { id: 'comm-brand-2', label: 'ShoeStore 戦略ワークショップ', meta: '開催予定 2024/07/22', status: 'planning' },
         ],
         strategies: [
           { id: 'strat-brand-1', label: '市場拡張 GTM プラン', meta: 'フェーズ1完了', status: 'active' },
@@ -198,18 +198,18 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
         ],
         programs: [
           {
-            id: 'prog-onboard',
-            name: 'オンボーディング改善プログラム',
+            id: 'prog-bidding',
+            name: '入札最適化プログラム',
             lead: '藤井 昂',
             status: '進行中',
             currentSprint: 'Sprint 3 / 6',
             deliverables: [
-              { id: 'deliv-prog-1', label: 'オンボーディング UX レポート', meta: 'レビュー待ち・2024/07/03', status: 'active' },
+              { id: 'deliv-prog-1', label: '広告入札改善レポート', meta: 'レビュー待ち・2024/07/03', status: 'active' },
               { id: 'deliv-prog-2', label: '新機能導入計画', meta: '準備中・2024/07/18', status: 'planning' },
             ],
             communications: [
               { id: 'comm-prog-1', label: '週次スタンドアップ', meta: '次回 2024/07/04', status: 'active' },
-              { id: 'comm-prog-2', label: 'Aurora CX チャンネル', meta: '未読 1 件', status: 'active' },
+              { id: 'comm-prog-2', label: 'ShoeStore CX チャンネル', meta: '未読 1 件', status: 'active' },
             ],
             strategies: [
               { id: 'strat-prog-1', label: 'エンゲージメント向上戦略', meta: '実行率 70%', status: 'active' },
@@ -217,13 +217,13 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
             ],
           },
           {
-            id: 'prog-loyalty',
-            name: 'ロイヤリティ向上プログラム',
+            id: 'prog-reporting',
+            name: '週次レポート自動化プログラム',
             lead: '近藤 沙耶',
             status: '計画中',
             currentSprint: 'Kickoff 準備',
             deliverables: [
-              { id: 'deliv-prog-3', label: 'ロイヤリティキャンバス', meta: '起案中', status: 'planning' },
+              { id: 'deliv-prog-3', label: '自動レポート設計', meta: '起案中', status: 'planning' },
             ],
             communications: [
               { id: 'comm-prog-3', label: '準備タスクフォロー', meta: '担当 3 名', status: 'active' },
@@ -235,9 +235,9 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
         ],
       },
       {
-        id: 'brand-lumen',
-        name: 'Lumen Street',
-        mission: '都市型スマート街灯のサブブランド',
+        id: 'brand-gadgets',
+        name: 'Gadgets+',
+        mission: 'スマートガジェットのサブスクリプション',
         lead: '原田 玲奈',
         health: '良好',
         healthMeta: '導入都市 26 / CSAT 4.6',
@@ -254,7 +254,7 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
         programs: [
           {
             id: 'prog-expansion',
-            name: '北米拡張プログラム',
+            name: '国際展開プログラム',
             lead: '吉本 海斗',
             status: '進行中',
             currentSprint: 'Sprint 2 / 8',
@@ -273,10 +273,10 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
     ],
   },
   {
-    id: 'cust-002',
-    name: 'Brighton Holdings',
-    owner: 'Michael Green',
-    industry: '不動産テック',
+    id: 'cust-tech-starter',
+    name: 'B社（Tech Starter）',
+    owner: '加藤 祐介',
+    industry: 'SaaS プラットフォーム',
     region: '大阪 / シンガポール',
     health: '成長',
     healthMeta: 'NRR 134% / Upsell 3 件',
@@ -291,9 +291,9 @@ const CUSTOMER_GRAPH: CustomerAccount[] = [
     ],
     brands: [
       {
-        id: 'brand-bright',
-        name: 'Bright Living',
-        mission: 'IoT リビング体験',
+        id: 'brand-futuretech',
+        name: 'FutureTech Gear',
+        mission: '次世代プロダクト向けツール群',
         lead: 'Sophie Tan',
         health: '良好',
         healthMeta: 'CSAT 4.8',
@@ -608,7 +608,6 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
 
     const items = buildModeNavItems(navDefinitions, sp, currentView, pathname, { section: activeSection })
     const breadcrumbs: Crumb[] = [
-      { href: '/', label: 'ホーム' },
       { href: createHrefWithView('/customers', sp, 'customer'), label: '顧客' },
     ]
 
@@ -813,7 +812,6 @@ function buildCustomerHierarchy({ sp, currentView, pathname }: BuilderArgs): Hie
   })
 
   const breadcrumbs: Crumb[] = [
-    { href: '/', label: 'ホーム' },
     { href: createHrefWithView('/customers', sp, 'customer'), label: '顧客' },
     {
       href: createHrefWithView(
@@ -930,8 +928,185 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
       requestedBrandId = candidate
     }
   }
+
+  if (!requestedBrandId) {
+    const activeSection = sp?.get('section') ?? 'list'
+    const navDefinitions: ModeNavDefinition[] = [
+      {
+        path: '/brands',
+        label: 'ブランド一覧',
+        description: '登録済みブランドを俯瞰',
+        icon: Landmark,
+        params: { section: 'list' },
+      },
+      {
+        path: '/brands',
+        label: 'コンテキスト',
+        description: 'ブランドポートフォリオの背景',
+        icon: Info,
+        params: { section: 'context' },
+      },
+      {
+        path: '/brands',
+        label: '成果物',
+        description: '横断的なブランド成果物',
+        icon: FilePenLine,
+        params: { section: 'deliverables' },
+      },
+      {
+        path: '/brands',
+        label: 'コミュニケーション',
+        description: '主要チャネルのハイライト',
+        icon: MessageSquare,
+        params: { section: 'communications' },
+      },
+      {
+        path: '/brands',
+        label: '戦略',
+        description: 'ブランド戦略の要点',
+        icon: Target,
+        params: { section: 'strategies' },
+      },
+    ]
+
+    const items = buildModeNavItems(navDefinitions, sp, currentView, pathname, {
+      section: activeSection,
+    })
+
+    const breadcrumbs: Crumb[] = [
+      { href: createHrefWithView('/brands', sp, 'brand'), label: 'ブランド' },
+    ]
+
+    const sections: HierarchySection[] = []
+    if (items.length) {
+      sections.push({
+        type: 'navigation',
+        id: 'brand-portfolio-navigation',
+        title: 'ブランドポートフォリオ',
+        description: 'ブランドごとのビューとナレッジ',
+        items,
+      })
+    }
+
+    const listItems: CollectionItem[] = allBrands.map(({ customer, brand }) => ({
+      id: brand.id,
+      label: brand.name,
+      meta: `${customer.name} / ${brand.keyMarkets}`,
+      status: brand.health === '注意' ? 'alert' : 'active',
+      href: createHrefWithView(
+        '/brands',
+        sp,
+        'brand',
+        { brandId: brand.id, section: 'overview' },
+      ),
+    }))
+
+    sections.push({
+      type: 'collection',
+      id: 'brand-portfolio-list',
+      title: 'ブランド一覧',
+      sectionKey: 'list',
+      emptyText: 'ブランドがまだ登録されていません',
+      items: listItems,
+    })
+
+    const relatedCustomers = new Set(allBrands.map(entry => entry.customer.id)).size
+    const activePrograms = allBrands.reduce((total, entry) => total + entry.brand.programs.length, 0)
+    const attentionBrands = allBrands.filter(entry => entry.brand.health === '注意').length
+
+    const portfolioContext: ContextEntry[] = [
+      { label: 'ブランド数', value: `${allBrands.length}件` },
+      { label: '関連顧客', value: `${relatedCustomers}社` },
+      { label: 'アクティブプログラム', value: `${activePrograms}件` },
+      { label: '要注意ブランド', value: `${attentionBrands}件`, meta: 'ヘルス指標が注意のブランド数' },
+    ]
+
+    sections.push({
+      type: 'context',
+      id: 'brand-portfolio-context',
+      title: 'ブランドポートフォリオのコンテキスト',
+      sectionKey: 'context',
+      entries: portfolioContext,
+    })
+
+    const aggregatedDeliverables: CollectionItem[] = allBrands
+      .flatMap(({ brand }) =>
+        brand.deliverables.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/brands',
+            sp,
+            'brand',
+            { brandId: brand.id, section: 'deliverables' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'brand-portfolio-deliverables',
+      title: '成果物',
+      sectionKey: 'deliverables',
+      emptyText: '横断的なブランド成果物はまだ登録されていません',
+      items: aggregatedDeliverables,
+    })
+
+    const aggregatedCommunications: CollectionItem[] = allBrands
+      .flatMap(({ brand }) =>
+        brand.communications.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/brands',
+            sp,
+            'brand',
+            { brandId: brand.id, section: 'communications' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'brand-portfolio-communications',
+      title: 'コミュニケーション',
+      sectionKey: 'communications',
+      emptyText: '共有のコミュニケーションはまだ登録されていません',
+      items: aggregatedCommunications,
+    })
+
+    const aggregatedStrategies: CollectionItem[] = allBrands
+      .flatMap(({ brand }) =>
+        brand.strategies.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/brands',
+            sp,
+            'brand',
+            { brandId: brand.id, section: 'strategies' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'brand-portfolio-strategies',
+      title: '戦略',
+      sectionKey: 'strategies',
+      emptyText: '横断的なブランド戦略はまだ登録されていません',
+      items: aggregatedStrategies,
+    })
+
+    return { breadcrumbs, sections, activeSection, selection: {} }
+  }
+
   const fallback = allBrands[0]
   const active = allBrands.find(entry => entry.brand.id === requestedBrandId) ?? fallback
+  if (!active) {
+    return { breadcrumbs: [], sections: [], activeSection: null, selection: {} }
+  }
+
   const { customer, brand } = active
   const activeSection = sp?.get('section') ?? 'context'
 
@@ -1001,18 +1176,6 @@ function buildBrandHierarchy({ sp, currentView, pathname }: BuilderArgs): Hierar
   })
 
   const breadcrumbs: Crumb[] = [
-    { href: '/', label: 'ホーム' },
-    { href: createHrefWithView('/customers', sp, 'customer'), label: '顧客' },
-    {
-      href: createHrefWithView(
-        '/customers',
-        sp,
-        'customer',
-        { customerId: customer.id },
-        { preserve: ['customerId'] },
-      ),
-      label: customer.name,
-    },
     { href: createHrefWithView('/brands', sp, 'brand'), label: 'ブランド' },
     {
       href: createHrefWithView(
@@ -1096,8 +1259,185 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
       requestedProgramId = candidate
     }
   }
+
+  if (!requestedProgramId) {
+    const activeSection = sp?.get('section') ?? 'list'
+    const navDefinitions: ModeNavDefinition[] = [
+      {
+        path: '/programs',
+        label: 'プログラム一覧',
+        description: '進行中の取り組みを俯瞰',
+        icon: Layers,
+        params: { section: 'list' },
+      },
+      {
+        path: '/programs',
+        label: 'コンテキスト',
+        description: 'ポートフォリオ全体の背景',
+        icon: Info,
+        params: { section: 'context' },
+      },
+      {
+        path: '/programs',
+        label: '成果物',
+        description: '主要アウトプットのハイライト',
+        icon: FilePenLine,
+        params: { section: 'deliverables' },
+      },
+      {
+        path: '/programs',
+        label: 'コミュニケーション',
+        description: '会議やタッチポイント',
+        icon: MessageSquare,
+        params: { section: 'communications' },
+      },
+      {
+        path: '/programs',
+        label: '戦略',
+        description: 'プログラム戦略の要約',
+        icon: Target,
+        params: { section: 'strategies' },
+      },
+    ]
+
+    const items = buildModeNavItems(navDefinitions, sp, currentView, pathname, {
+      section: activeSection,
+    })
+
+    const breadcrumbs: Crumb[] = [
+      { href: createHrefWithView('/programs', sp, 'program'), label: 'プログラム' },
+    ]
+
+    const sections: HierarchySection[] = []
+    if (items.length) {
+      sections.push({
+        type: 'navigation',
+        id: 'program-portfolio-navigation',
+        title: 'プログラムポートフォリオ',
+        description: 'プログラム単位のビューを選択',
+        items,
+      })
+    }
+
+    const listItems: CollectionItem[] = allPrograms.map(({ customer, brand, program }) => ({
+      id: program.id,
+      label: program.name,
+      meta: `${brand.name} / ${customer.name}`,
+      status: program.status.includes('計画') ? 'planning' : 'active',
+      href: createHrefWithView(
+        '/programs',
+        sp,
+        'program',
+        { programId: program.id, section: 'overview' },
+      ),
+    }))
+
+    sections.push({
+      type: 'collection',
+      id: 'program-portfolio-list',
+      title: 'プログラム一覧',
+      sectionKey: 'list',
+      emptyText: 'プログラムがまだ登録されていません',
+      items: listItems,
+    })
+
+    const totalBrands = new Set(allPrograms.map(entry => entry.brand.id)).size
+    const totalCustomers = new Set(allPrograms.map(entry => entry.customer.id)).size
+    const activeCount = allPrograms.filter(entry => entry.program.status.includes('進行')).length
+
+    const portfolioContext: ContextEntry[] = [
+      { label: 'プログラム数', value: `${allPrograms.length}件` },
+      { label: '参画ブランド', value: `${totalBrands}ブランド` },
+      { label: '参画顧客', value: `${totalCustomers}社` },
+      { label: '進行中', value: `${activeCount}件`, meta: '「進行中」のステータス数' },
+    ]
+
+    sections.push({
+      type: 'context',
+      id: 'program-portfolio-context',
+      title: 'プログラムポートフォリオのコンテキスト',
+      sectionKey: 'context',
+      entries: portfolioContext,
+    })
+
+    const aggregatedDeliverables: CollectionItem[] = allPrograms
+      .flatMap(({ program }) =>
+        program.deliverables.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/programs',
+            sp,
+            'program',
+            { programId: program.id, section: 'deliverables' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'program-portfolio-deliverables',
+      title: '成果物',
+      sectionKey: 'deliverables',
+      emptyText: '横断的な成果物はまだ登録されていません',
+      items: aggregatedDeliverables,
+    })
+
+    const aggregatedCommunications: CollectionItem[] = allPrograms
+      .flatMap(({ program }) =>
+        program.communications.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/programs',
+            sp,
+            'program',
+            { programId: program.id, section: 'communications' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'program-portfolio-communications',
+      title: 'コミュニケーション',
+      sectionKey: 'communications',
+      emptyText: '横断的なコミュニケーションはまだ登録されていません',
+      items: aggregatedCommunications,
+    })
+
+    const aggregatedStrategies: CollectionItem[] = allPrograms
+      .flatMap(({ program }) =>
+        program.strategies.slice(0, 2).map(item => ({
+          ...item,
+          href: createHrefWithView(
+            '/programs',
+            sp,
+            'program',
+            { programId: program.id, section: 'strategies' },
+          ),
+        })),
+      )
+      .slice(0, 6)
+
+    sections.push({
+      type: 'collection',
+      id: 'program-portfolio-strategies',
+      title: '戦略',
+      sectionKey: 'strategies',
+      emptyText: '横断的なプログラム戦略はまだ登録されていません',
+      items: aggregatedStrategies,
+    })
+
+    return { breadcrumbs, sections, activeSection, selection: {} }
+  }
+
   const fallback = allPrograms[0]
   const active = allPrograms.find(entry => entry.program.id === requestedProgramId) ?? fallback
+  if (!active) {
+    return { breadcrumbs: [], sections: [], activeSection: null, selection: {} }
+  }
+
   const { customer, brand, program } = active
   const activeSection = sp?.get('section') ?? 'context'
 
@@ -1168,29 +1508,6 @@ function buildProgramHierarchy({ sp, currentView, pathname }: BuilderArgs): Hier
   })
 
   const breadcrumbs: Crumb[] = [
-    { href: '/', label: 'ホーム' },
-    { href: createHrefWithView('/customers', sp, 'customer'), label: '顧客' },
-    {
-      href: createHrefWithView(
-        '/customers',
-        sp,
-        'customer',
-        { customerId: customer.id },
-        { preserve: ['customerId'] },
-      ),
-      label: customer.name,
-    },
-    { href: createHrefWithView('/brands', sp, 'brand'), label: 'ブランド' },
-    {
-      href: createHrefWithView(
-        '/brands',
-        sp,
-        'brand',
-        { brandId: brand.id },
-        { preserve: ['brandId'] },
-      ),
-      label: brand.name,
-    },
     { href: createHrefWithView('/programs', sp, 'program'), label: 'プログラム' },
     {
       href: createHrefWithView(

--- a/components/ViewSwitch.tsx
+++ b/components/ViewSwitch.tsx
@@ -1,135 +1,59 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { Users2, Landmark, Layers, ChevronDown, Check } from 'lucide-react'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { BookOpenCheck, FolderKanban, Landmark, Layers, User, Users2 } from 'lucide-react'
+import type { ComponentType } from 'react'
 
-const VIEWS = [
-  { id: 'customer', label: '顧客', Icon: Users2 },
-  { id: 'brand', label: 'ブランド', Icon: Landmark },
-  { id: 'program', label: 'プログラム', Icon: Layers },
-] as const
+export type ViewId = 'projects' | 'customer' | 'brand' | 'program' | 'playbook' | 'settings'
 
-export type ViewId = typeof VIEWS[number]['id']
+export type ViewConfig = {
+  id: ViewId
+  label: string
+  icon: ComponentType<any>
+  home: string
+}
+
+export const VIEWS: ViewConfig[] = [
+  { id: 'projects', label: 'Myプロジェクト', icon: FolderKanban, home: '/projects/my' },
+  { id: 'customer', label: '顧客', icon: Users2, home: '/customers' },
+  { id: 'brand', label: 'ブランド', icon: Landmark, home: '/brands' },
+  { id: 'program', label: 'プログラム', icon: Layers, home: '/programs' },
+  { id: 'playbook', label: 'プレイブック', icon: BookOpenCheck, home: '/playbooks' },
+  { id: 'settings', label: 'アカウント設定', icon: User, home: '/settings' },
+]
+
+const PATH_VIEW_MAP: Array<{ prefix: string; view: ViewId }> = [
+  { prefix: '/projects/my', view: 'projects' },
+  { prefix: '/customers', view: 'customer' },
+  { prefix: '/brands', view: 'brand' },
+  { prefix: '/programs', view: 'program' },
+  { prefix: '/playbooks', view: 'playbook' },
+  { prefix: '/settings', view: 'settings' },
+  { prefix: '/datasources', view: 'settings' },
+]
+
+function isViewId(value: unknown): value is ViewId {
+  return typeof value === 'string' && VIEWS.some(view => view.id === value)
+}
+
+export function resolveViewHome(id: ViewId): string {
+  const view = VIEWS.find(v => v.id === id)
+  return view?.home ?? '/'
+}
 
 export function useCurrentView(): ViewId {
   const pathname = usePathname() || '/'
   const sp = useSearchParams()
-  const forcedView = (() => {
-    if (pathname === '/customers' || pathname.startsWith('/customers/')) return 'customer'
-    if (pathname === '/brands' || pathname.startsWith('/brands/')) return 'brand'
-    if (pathname === '/programs' || pathname.startsWith('/programs/')) return 'program'
-    return null
-  })()
 
-  if (forcedView) {
-    return forcedView
+  const forced = PATH_VIEW_MAP.find(entry => pathname === entry.prefix || pathname.startsWith(`${entry.prefix}/`))
+  if (forced) {
+    return forced.view
   }
 
-  const v = sp?.get('v') as ViewId | null
-  if (v && ['customer', 'brand', 'program'].includes(v)) {
-    return v
+  const fromQuery = sp?.get('v')
+  if (isViewId(fromQuery)) {
+    return fromQuery
   }
 
-  return 'customer'
-}
-
-export function ViewSwitch() {
-  const router = useRouter()
-  const sp = useSearchParams()
-  const current = useCurrentView()
-  const [isOpen, setIsOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [])
-
-  const setView = (next: ViewId) => {
-    const viewHomes: Record<ViewId, string> = {
-      customer: '/customers',
-      brand: '/brands',
-      program: '/programs',
-    }
-
-    const params = new URLSearchParams(sp?.toString() || '')
-    params.set('v', next)
-    router.push(`${viewHomes[next]}?${params.toString()}`)
-  }
-
-  const selectedView = VIEWS.find(view => view.id === current) ?? VIEWS[0]
-  const SelectedIcon = selectedView.Icon
-
-  return (
-    <div ref={menuRef} className="relative inline-flex text-sm font-medium">
-      <button
-        type="button"
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        aria-label="ビュー切り替え"
-        onClick={() => setIsOpen(open => !open)}
-        className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white py-2 pl-3 pr-2 text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
-      >
-        <span className="grid h-6 w-6 place-items-center rounded-xl bg-slate-100 text-slate-600">
-          <SelectedIcon className="h-4 w-4" aria-hidden="true" />
-        </span>
-        <span>{selectedView.label}</span>
-        <ChevronDown
-          className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          aria-hidden="true"
-        />
-      </button>
-      {isOpen ? (
-        <div
-          role="menu"
-          aria-label="ビューの選択肢"
-          className="absolute right-0 top-full z-20 mt-2 w-48 rounded-2xl border border-slate-200 bg-white p-2 shadow-lg ring-1 ring-black/5"
-        >
-          {VIEWS.map(({ id, label, Icon }) => {
-            const isActive = current === id
-            return (
-              <button
-                key={id}
-                type="button"
-                role="menuitemradio"
-                aria-checked={isActive}
-                onClick={() => {
-                  setIsOpen(false)
-                  if (id !== current) {
-                    setView(id)
-                  }
-                }}
-                className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500/60 ${
-                  isActive ? 'bg-indigo-50 text-indigo-700' : 'text-slate-700'
-                }`}
-              >
-                <span className="grid h-7 w-7 place-items-center rounded-xl bg-slate-100">
-                  <Icon className="h-4 w-4" aria-hidden="true" />
-                </span>
-                <span className="flex-1 font-medium">{label}</span>
-                {isActive ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
-              </button>
-            )
-          })}
-        </div>
-      ) : null}
-    </div>
-  )
+  return 'projects'
 }


### PR DESCRIPTION
## Summary
- add a dedicated settings mode so the sidebar rail can surface account actions alongside the other modes
- move the data source link into the settings submenu so it appears when the settings mode is active
- map settings and data source routes to the new settings view metadata for query-aware navigation

## Testing
- npm run lint *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d631de9d908328a7d5c1d6f8dbfd73