### PR TITLE
Add hierarchy detail layouts to customer, brand, and program pages

### DIFF
--- a/app/brands/[id]/page.tsx
+++ b/app/brands/[id]/page.tsx
@@ -1,44 +1,96 @@
 'use client'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
 import { CTA } from '@/components/ui/CTA'
+import type { ReactNode } from 'react'
 
-const DATA: Record<string, any> = {
+type BrandSnapshot = {
+  name: string
+  notes: string[]
+}
+
+const DATA: Record<string, BrandSnapshot> = {
   brd_shoestore: { name: 'ShoeStore', notes: ['CPAが目標より+12%', '在庫更新が遅延'] },
   brd_gadgets: { name: 'Gadgets+', notes: ['CVタグの改修予定'] },
   brd_futuretech: { name: 'FutureTech Gear', notes: ['新商品のローンチ準備', '在庫連携テスト進行中'] },
 }
 
 export default function BrandDetail({ params }: { params: { id: string } }) {
-  const b = DATA[params.id] ?? { name: params.id, notes: [] }
+  const snapshot: BrandSnapshot = DATA[params.id] ?? { name: params.id, notes: [] }
   return (
-    <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }, { href: `/brands/${params.id}`, label: b.name }]}>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="kpi">
-          <div className="text-sm text-slate-500">KPIカード</div>
-          <div className="mt-2 text-sm text-slate-600">CPA / ROAS / 新規比率 など</div>
-        </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">今週のRun</div>
-          <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-1">
-            <li>入札最適化（毎日）</li>
-            <li>在庫フィード検証</li>
-          </ul>
-        </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">アラート</div>
-          <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-1">
-            {b.notes.map((n: string, i: number) => <li key={i}>{n}</li>)}
-          </ul>
-        </div>
-      </div>
-      <div className="mt-4 card p-4">
-        <div className="font-semibold">アクション</div>
-        <div className="mt-2 flex flex-wrap gap-2">
-          <CTA>新規キャンペーン起案</CTA>
-          <CTA>広告文の最適化</CTA>
-          <CTA variant="outline">レポート出力</CTA>
-        </div>
-      </div>
+    <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }, { href: `/brands/${params.id}`, label: snapshot.name }]}>
+      <BrandDetailContent snapshot={snapshot} />
     </Shell>
+  )
+}
+
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function BrandDetailContent({ snapshot }: { snapshot: BrandSnapshot }) {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'overview'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  let mainContent: ReactNode
+  if (sectionKey === 'overview') {
+    mainContent = (
+      <div className="space-y-6">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">KPIカード</div>
+            <div className="mt-2 text-sm text-slate-600">CPA / ROAS / 新規比率 など</div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">今週のRun</div>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
+              <li>入札最適化（毎日）</li>
+              <li>在庫フィード検証</li>
+            </ul>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">アラート</div>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
+              {snapshot.notes.map((note, index) => (
+                <li key={index}>{note}</li>
+              ))}
+              {snapshot.notes.length === 0 ? <li>特筆すべきアラートはありません</li> : null}
+            </ul>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="font-semibold">アクション</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <CTA>新規キャンペーン起案</CTA>
+            <CTA>広告文の最適化</CTA>
+            <CTA variant="outline">レポート出力</CTA>
+          </div>
+        </div>
+      </div>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail />
+    </div>
   )
 }

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
+import type { ReactNode } from 'react'
 
 const brands = [
   { id: 'brand-shoestore', name: 'ShoeStore', account: 'A社（Global Retail Inc.）' },
@@ -9,25 +10,64 @@ const brands = [
   { id: 'brand-futuretech', name: 'FutureTech Gear', account: 'B社（Tech Starter）' },
 ]
 
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function BrandsContent() {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'list'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  let mainContent: ReactNode
+  if (sectionKey === 'list') {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">ブランド一覧</h2>
+          <AddButton href="/brands/new">新規登録</AddButton>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {brands.map(b => (
+            <Link key={b.id} href={`/brands/${b.id}`} className="card card-hover flex flex-col gap-1 p-4">
+              <div className="font-medium text-slate-900">{b.name}</div>
+              <div className="text-sm text-slate-500">{b.account}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail />
+    </div>
+  )
+}
+
 export default function Brands() {
   return (
     <Shell crumbs={[{ href: '/brands', label: 'ブランド一覧' }]}>
-      <div className="space-y-8">
-        <section className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-slate-900">ブランド一覧</h2>
-            <AddButton href="/brands/new">新規登録</AddButton>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            {brands.map(b => (
-              <Link key={b.id} href={`/brands/${b.id}`} className="card card-hover flex flex-col gap-1 p-4">
-                <div className="font-medium text-slate-900">{b.name}</div>
-                <div className="text-sm text-slate-500">{b.account}</div>
-              </Link>
-            ))}
-          </div>
-        </section>
-      </div>
+      <BrandsContent />
     </Shell>
   )
 }

--- a/app/customers/[id]/page.tsx
+++ b/app/customers/[id]/page.tsx
@@ -1,11 +1,20 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
 import { CTA } from '@/components/ui/CTA'
 import { ChevronRight } from 'lucide-react'
+import type { ReactNode } from 'react'
 
 // Demo data
-const DATA: Record<string, any> = {
+type CustomerSnapshot = {
+  name: string
+  kpi: { cpa?: number; roas?: number; progress?: number }
+  contract: { budget?: number; consumed?: number }
+  issues: string[]
+  projects: Array<{ id: string; name: string }>
+}
+
+const DATA: Record<string, CustomerSnapshot> = {
   acc_globalretail: {
     name: 'A社（Global Retail Inc.）',
     kpi: { cpa: 1200, roas: 2.1, progress: 0.76 },
@@ -30,65 +39,124 @@ function formatJPY(n: number) {
 }
 
 export default function CustomerDetail({ params }: { params: { id: string } }) {
-  const c = DATA[params.id] ?? { name: params.id, kpi:{}, contract:{}, issues:[], projects:[] }
+  const snapshot: CustomerSnapshot =
+    DATA[params.id] ?? { name: params.id, kpi: {}, contract: {}, issues: [], projects: [] }
   const crumbs = [
     { href: '/customers', label: '顧客一覧' },
-    { href: `/customers/${params.id}`, label: c.name },
+    { href: `/customers/${params.id}`, label: snapshot.name },
   ]
-  const consumption = c.contract?.consumed ?? 0
-  const budget = c.contract?.budget ?? 1
-  const rate = Math.min(1, Math.max(0, consumption / budget))
-  const pct = Math.round(rate * 100)
 
   return (
     <Shell crumbs={crumbs}>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="kpi">
-          <div className="text-sm text-slate-500">課題リスト</div>
-          <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-1">
-            {c.issues.map((it: string, i: number) => <li key={i}>{it}</li>)}
-            {c.issues.length === 0 && <li>特筆すべき課題はありません</li>}
-          </ul>
-        </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">契約状況</div>
-          <div className="mt-2 text-sm">契約金額：{formatJPY(budget)}</div>
-          <div className="text-sm">消化額：{formatJPY(consumption)} <span className="text-slate-500">（{pct}%）</span></div>
-          <div className="mt-2 h-2 w-full bg-slate-200 rounded-full overflow-hidden">
-            <div className="h-2 bg-indigo-600" style={{ width: `${pct}%` }} />
+      <CustomerDetailContent snapshot={snapshot} />
+    </Shell>
+  )
+}
+
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function CustomerDetailContent({ snapshot }: { snapshot: CustomerSnapshot }) {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'overview'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  const consumption = snapshot.contract?.consumed ?? 0
+  const budget = snapshot.contract?.budget ?? 1
+  const rate = Math.min(1, Math.max(0, consumption / budget))
+  const pct = Math.round(rate * 100)
+
+  let mainContent: ReactNode
+  if (sectionKey === 'overview') {
+    mainContent = (
+      <div className="space-y-6">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">課題リスト</div>
+            <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 space-y-1">
+              {snapshot.issues.map((it, i) => (
+                <li key={i}>{it}</li>
+              ))}
+              {snapshot.issues.length === 0 && <li>特筆すべき課題はありません</li>}
+            </ul>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">契約状況</div>
+            <div className="mt-2 text-sm">契約金額：{formatJPY(budget)}</div>
+            <div className="text-sm">
+              消化額：{formatJPY(consumption)} <span className="text-slate-500">（{pct}%）</span>
+            </div>
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-200">
+              <div className="h-2 bg-indigo-600" style={{ width: `${pct}%` }} />
+            </div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">KPI達成率</div>
+            <div className="mt-2 text-2xl font-semibold">{Math.round((snapshot.kpi.progress ?? 0) * 100)}%</div>
+            <div className="text-xs text-slate-500">
+              CPA: {snapshot.kpi.cpa ?? '—'} / ROAS: {snapshot.kpi.roas ?? '—'}
+            </div>
           </div>
         </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">KPI達成率</div>
-          <div className="mt-2 text-2xl font-semibold">{Math.round((c.kpi.progress ?? 0) * 100)}%</div>
-          <div className="text-xs text-slate-500">CPA: {c.kpi.cpa ?? '—'} / ROAS: {c.kpi.roas ?? '—'}</div>
-        </div>
-      </div>
 
-      <div className="mt-4 card p-4">
-        <div className="font-semibold">アクション</div>
-        <div className="mt-2 flex flex-wrap gap-2">
-          <CTA onClick={() => alert('提案書最適化（デモ）')}>提案書最適化</CTA>
-          <CTA onClick={() => alert('レポーティング開始（デモ）')}>レポーティング開始</CTA>
-          <CTA variant="outline" onClick={() => alert('新プロジェクト作成（デモ）')}>新プロジェクト作成</CTA>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="font-semibold">アクション</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <CTA onClick={() => alert('提案書最適化（デモ）')}>提案書最適化</CTA>
+            <CTA onClick={() => alert('レポーティング開始（デモ）')}>レポーティング開始</CTA>
+            <CTA variant="outline" onClick={() => alert('新プロジェクト作成（デモ）')}>
+              新プロジェクト作成
+            </CTA>
+          </div>
         </div>
-      </div>
 
-      <div className="mt-4 card p-4">
-        <div className="font-semibold">関連プロジェクト</div>
-        <div className="mt-2 grid gap-2">
-          {c.projects.map((p: any) => (
-            <Link
-              key={p.id}
-              href={`/projects/${p.id}`}
-              className="group flex items-center justify-between gap-3 rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-all duration-150 hover:-translate-y-0.5 hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200"
-            >
-              <span>{p.name}</span>
-              <ChevronRight className="h-4 w-4 text-slate-400 transition-colors duration-150 group-hover:text-indigo-500" aria-hidden="true" />
-            </Link>
-          ))}
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="font-semibold">関連プロジェクト</div>
+          <div className="mt-2 grid gap-2">
+            {snapshot.projects.map(project => (
+              <Link
+                key={project.id}
+                href={`/projects/${project.id}`}
+                className="group flex items-center justify-between gap-3 rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition-all duration-150 hover:-translate-y-0.5 hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200"
+              >
+                <span>{project.name}</span>
+                <ChevronRight
+                  className="h-4 w-4 text-slate-400 transition-colors duration-150 group-hover:text-indigo-500"
+                  aria-hidden="true"
+                />
+              </Link>
+            ))}
+            {snapshot.projects.length === 0 ? (
+              <p className="text-sm text-slate-500">関連プロジェクトはまだ登録されていません。</p>
+            ) : null}
+          </div>
         </div>
       </div>
-    </Shell>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail />
+    </div>
   )
 }

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -1,32 +1,72 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
 import { AddButton } from '@/components/ui/AddButton'
+import type { ReactNode } from 'react'
 
 const customers = [
   { id: 'cust-global-retail', name: 'A社（Global Retail Inc.）', website: 'https://www.globalretail.example' },
   { id: 'cust-tech-starter', name: 'B社（Tech Starter）', website: 'https://www.techstarter.example' },
 ]
 
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function CustomersContent() {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'list'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  let mainContent: ReactNode
+  if (sectionKey === 'list') {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">顧客一覧</h2>
+          <AddButton href="/customers/new">新規登録</AddButton>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          {customers.map(c => (
+            <Link key={c.id} href={`/customers/${c.id}`} className="card card-hover flex flex-col gap-1 p-4">
+              <div className="font-medium text-slate-900">{c.name}</div>
+              <div className="text-sm text-slate-500">{c.website}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail />
+    </div>
+  )
+}
+
 export default function Customers() {
   return (
     <Shell crumbs={[{ href: '/customers', label: '顧客一覧' }]}>
-      <div className="space-y-8">
-        <section className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-slate-900">顧客一覧</h2>
-            <AddButton href="/customers/new">新規登録</AddButton>
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            {customers.map(c => (
-              <Link key={c.id} href={`/customers/${c.id}`} className="card card-hover flex flex-col gap-1 p-4">
-                <div className="font-medium text-slate-900">{c.name}</div>
-                <div className="text-sm text-slate-500">{c.website}</div>
-              </Link>
-            ))}
-          </div>
-        </section>
-      </div>
+      <CustomersContent />
     </Shell>
   )
 }

--- a/app/programs/[id]/page.tsx
+++ b/app/programs/[id]/page.tsx
@@ -1,32 +1,85 @@
 'use client'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
 import { CTA } from '@/components/ui/CTA'
+import type { ReactNode } from 'react'
 
 export default function ProgramDetail({ params }: { params: { id: string } }) {
   return (
     <Shell crumbs={[{ href: '/programs', label: 'プログラム一覧' }, { href: `/programs/${params.id}`, label: params.id }]}>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div className="kpi">
-          <div className="text-sm text-slate-500">横断成果比較</div>
-          <div className="mt-2 text-sm text-slate-600">ブランド・顧客をまたいだKPI比較のダミー</div>
-        </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">Playbook品質</div>
-          <div className="mt-2 text-sm text-slate-600">版比較・回帰失敗・承認状況</div>
-        </div>
-        <div className="kpi">
-          <div className="text-sm text-slate-500">進行中プロジェクト</div>
-          <div className="mt-2 text-sm text-slate-600">代表的な進行列（ダミー）</div>
-        </div>
-      </div>
-      <div className="mt-4 card p-4">
-        <div className="font-semibold">アクション</div>
-        <div className="mt-2 flex flex-wrap gap-2">
-          <CTA>新規Playbookの検証</CTA>
-          <CTA>回帰テスト実行</CTA>
-          <CTA variant="outline">横断レポート生成</CTA>
-        </div>
-      </div>
+      <ProgramDetailContent programId={params.id} />
     </Shell>
+  )
+}
+
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function ProgramDetailContent({ programId }: { programId: string }) {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'overview'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  let mainContent: ReactNode
+  if (sectionKey === 'overview') {
+    mainContent = (
+      <div className="space-y-6">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">横断成果比較</div>
+            <div className="mt-2 text-sm text-slate-600">ブランド・顧客をまたいだKPI比較のダミー</div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">Playbook品質</div>
+            <div className="mt-2 text-sm text-slate-600">版比較・回帰失敗・承認状況</div>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="text-sm text-slate-500">進行中プロジェクト</div>
+            <div className="mt-2 text-sm text-slate-600">代表的な進行列（ダミー）</div>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="font-semibold">アクション</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <CTA>新規Playbookの検証</CTA>
+            <CTA>回帰テスト実行</CTA>
+            <CTA variant="outline">横断レポート生成</CTA>
+          </div>
+        </div>
+      </div>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail emptyState={<PlaceholderEmptyState programId={programId} />} />
+    </div>
+  )
+}
+
+function PlaceholderEmptyState({ programId }: { programId: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>{programId} の詳細データはサンプルとして表示されています。</p>
+      <p className="mt-2">左側のセクションを切り替えてコンテキストを参照してください。</p>
+    </div>
   )
 }

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
-import { Shell } from '@/components/Shell'
+import { HierarchyDetail, Shell, useHierarchyState } from '@/components/Shell'
+import type { ReactNode } from 'react'
 
 const programs = [
   { id: 'prog-bidding', name: '入札最適化プログラム' },
@@ -8,21 +9,60 @@ const programs = [
   { id: 'prog-expansion', name: '国際展開プログラム' },
 ]
 
+function SectionPlaceholder({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-6 text-center text-sm text-slate-500">
+      <p>「{title}」セクションの詳細は右側のパネルで確認できます。</p>
+      {description ? <p className="mt-2 text-xs text-slate-500">{description}</p> : null}
+    </div>
+  )
+}
+
+function ProgramsContent() {
+  const { activeSection, navigationItems } = useHierarchyState()
+  const sectionKey = activeSection ?? 'list'
+  const activeNav = navigationItems.find(item => item.params?.section === sectionKey)
+  const sectionLabel = activeNav?.label ?? 'セクション'
+  const sectionDescription = activeNav?.description
+
+  let mainContent: ReactNode
+  if (sectionKey === 'list') {
+    mainContent = (
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-slate-900">プログラム一覧</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {programs.map(p => (
+            <Link key={p.id} href={`/programs/${p.id}`} className="card card-hover flex flex-col gap-1 p-4">
+              <div className="font-medium text-slate-900">{p.name}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    )
+  } else {
+    mainContent = (
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900">{sectionLabel}</h2>
+          {sectionDescription ? <p className="text-sm text-slate-500">{sectionDescription}</p> : null}
+        </div>
+        <SectionPlaceholder title={sectionLabel} description={sectionDescription} />
+      </section>
+    )
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="space-y-8">{mainContent}</div>
+      <HierarchyDetail />
+    </div>
+  )
+}
+
 export default function Programs() {
   return (
     <Shell crumbs={[{ href: '/programs', label: 'プログラム一覧' }]}>
-      <div className="space-y-8">
-        <section className="space-y-3">
-          <h2 className="text-lg font-semibold text-slate-900">プログラム一覧</h2>
-          <div className="grid gap-3 md:grid-cols-2">
-            {programs.map(p => (
-              <Link key={p.id} href={`/programs/${p.id}`} className="card card-hover flex flex-col gap-1 p-4">
-                <div className="font-medium text-slate-900">{p.name}</div>
-              </Link>
-            ))}
-          </div>
-        </section>
-      </div>
+      <ProgramsContent />
     </Shell>
   )
 }


### PR DESCRIPTION
## Summary
- integrate the HierarchyDetail panel into customer, brand, and program list/detail pages with two-column layouts
- adjust each page to react to the current hierarchy section so existing card views only render in their matching sections
- add lightweight placeholder messaging where dedicated section content is not yet implemented

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d77fcb9ed8832884f2b191510fe419